### PR TITLE
Update analyzers: MA0015 option and CA2208 disable

### DIFF
--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -66,7 +66,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.29" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.46" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
@@ -2,6 +2,8 @@
 is_global = true
 global_level = 0
 
+dotnet_diagnostic.MA0015.consider_member_access_as_parameter = true
+
 # MA0001: StringComparison is missing
 # Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0001.md
 # Enabled: True, Severity: suggestion
@@ -633,7 +635,7 @@ dotnet_diagnostic.MA0126.severity = warning
 
 # MA0127: Use String.Equals instead of is pattern
 # Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0127.md
-# Enabled: False, Severity: warning
+# Enabled: True, Severity: silent
 dotnet_diagnostic.MA0127.severity = none
 
 # MA0128: Use 'is' operator instead of SequenceEqual
@@ -950,4 +952,14 @@ dotnet_diagnostic.MA0189.severity = suggestion
 # Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0190.md
 # Enabled: True, Severity: suggestion
 dotnet_diagnostic.MA0190.severity = suggestion
+
+# MA0191: Do not use the null-forgiving operator
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0191.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0191.severity = none
+
+# MA0192: Use HasFlag instead of bitwise checks
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0192.md
+# Enabled: False, Severity: suggestion
+dotnet_diagnostic.MA0192.severity = none
 

--- a/src/configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig
+++ b/src/configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig
@@ -966,7 +966,7 @@ dotnet_diagnostic.CA2207.severity = warning
 # CA2208: Instantiate argument exceptions correctly
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
 # Enabled: True, Severity: suggestion
-dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.CA2208.severity = none
 
 # CA2211: Non-constant fields should not be visible
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211


### PR DESCRIPTION
## Why
`meziantou/Meziantou.Analyzer#1059` added `MA0015.consider_member_access_as_parameter`. This updates this repo to consume that option with the latest analyzer package, and also applies the requested CA2208 disablement.

## What changed
- Bumped `Meziantou.Analyzer` from `3.0.29` to `3.0.46` in `src/common/Common.props`
- Enabled `dotnet_diagnostic.MA0015.consider_member_access_as_parameter = true` in `src/configuration/Analyzer.Meziantou.Analyzer.editorconfig`
- Regenerated Meziantou analyzer configuration content for the new version (including new MA0191/MA0192 entries and updated MA0127 metadata comments)
- Set `dotnet_diagnostic.CA2208.severity = none` in `src/configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig`

## Notes for reviewers
- The extra MA0127/MA0191/MA0192 diffs are generator-driven side effects of upgrading `Meziantou.Analyzer`, not separate manual policy changes.
- Full `dotnet test tests/Meziantou.Sdk.Tests` currently hangs in this environment after partial xUnit progress; generator and solution build complete successfully.