### PR TITLE
Clarify README introduction value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 - [![Meziantou.NET.Sdk on NuGet](https://img.shields.io/nuget/v/Meziantou.NET.Sdk.svg)](https://www.nuget.org/packages/Meziantou.NET.Sdk/)
 
-MSBuild SDK that provides:
-- Opinionated defaults for .NET projects
-- Naming conventions
-- Static analysis with Roslyn analyzers
+MSBuild SDK that helps standardize build and quality settings across repositories. It provides:
+- Opinionated defaults and naming conventions for .NET projects
+- Best practices for build, CI, and test workflows
+- A static analysis baseline with Roslyn analyzers
 - Set `ContinuousIntegrationBuild` based on the context
 - dotnet test features
   - Dump on crash or hang


### PR DESCRIPTION
## Why
The README introduction did not clearly state that this SDK solves cross-repository standardization and provides a best-practices and static-analysis baseline. Making that explicit helps new adopters understand the value quickly.

## What changed
Updated the introduction to say the SDK:
- standardizes build and quality settings across repositories
- provides best practices for build, CI, and test workflows
- provides a static analysis baseline with Roslyn analyzers

This is a documentation-only change.