### PR TITLE
Normalize MSBuild path separators to forward slashes

### DIFF
--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)\ContinuousIntegrationBuild.props" />
+  <Import Project="$(MSBuildThisFileDirectory)/ContinuousIntegrationBuild.props" />
 
   <PropertyGroup>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -84,11 +84,11 @@
 
   <ItemGroup>
     <!-- Add all editorconfig files -->
-    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)\..\configuration\*.editorconfig"
-                       Exclude="$(MSBuildThisFileDirectory)\..\configuration\Meziantou.NET.Sdk.*.editorconfig" />
-    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)\..\configuration\$(MeziantouSdkName).editorconfig"
-                       Condition="'$(MeziantouSdkName)' != '' AND Exists('$(MSBuildThisFileDirectory)\..\configuration\$(MeziantouSdkName).editorconfig')" />
-    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)\..\configuration\Meziantou.NET.Sdk.SingleFileApp.editorconfig"
+    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)../configuration/*.editorconfig"
+                       Exclude="$(MSBuildThisFileDirectory)../configuration/Meziantou.NET.Sdk.*.editorconfig" />
+    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)../configuration/$(MeziantouSdkName).editorconfig"
+                       Condition="'$(MeziantouSdkName)' != '' AND Exists('$(MSBuildThisFileDirectory)../configuration/$(MeziantouSdkName).editorconfig')" />
+    <EditorConfigFiles Include="$(MSBuildThisFileDirectory)../configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig"
                        Condition="'$(MeziantouSingleFileApp)' == 'true'" />
   </ItemGroup>
 

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
-	<Import Project="$(MSBuildThisFileDirectory)\Tests.targets" Condition="'$(IsTestProject)' == 'true'" />
-	<Import Project="$(MSBuildThisFileDirectory)\Npm.targets" />
+	<Import Project="$(MSBuildThisFileDirectory)/Tests.targets" Condition="'$(IsTestProject)' == 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)/Npm.targets" />
 
 	<PropertyGroup>
 		<TargetFramework Condition="'$(TargetFramework)' == '' AND '$(TargetFrameworks)' == '' AND '$(NETCoreAppMaximumVersion)' != ''">net$(NETCoreAppMaximumVersion)</TargetFramework>
@@ -62,8 +62,8 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<AdditionalFiles Include="$(MSBuildThisFileDirectory)\..\configuration\BannedSymbols.txt" Condition="'$(IncludeDefaultBannedSymbols)' != 'false'" Visible="false" />
-		<AdditionalFiles Include="$(MSBuildThisFileDirectory)\..\configuration\BannedSymbols.NewtonsoftJson.txt" Condition="'$(BannedNewtonsoftJsonSymbols)' != 'false'" Visible="false" />
+		<AdditionalFiles Include="$(MSBuildThisFileDirectory)../configuration/BannedSymbols.txt" Condition="'$(IncludeDefaultBannedSymbols)' != 'false'" Visible="false" />
+		<AdditionalFiles Include="$(MSBuildThisFileDirectory)../configuration/BannedSymbols.NewtonsoftJson.txt" Condition="'$(BannedNewtonsoftJsonSymbols)' != 'false'" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
@@ -120,23 +120,23 @@
 				<PackageIcon>icon.png</PackageIcon>
 			</PropertyGroup>
 			<ItemGroup>
-				<None Include="$(MSBuildThisFileDirectory)\..\icon.png" Pack="true" PackagePath="" Visible="false" />
+				<None Include="$(MSBuildThisFileDirectory)../icon.png" Pack="true" PackagePath="" Visible="false" />
 			</ItemGroup>
 		</When>
 	</Choose>
 
 	<PropertyGroup>
-		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)\README.md')">$(MSBuildProjectDirectory)\README.md</_PackageReadmeFilePath>
-		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)\readme.md')">$(MSBuildProjectDirectory)\readme.md</_PackageReadmeFilePath>
-		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)\Readme.md')">$(MSBuildProjectDirectory)\Readme.md</_PackageReadmeFilePath>
-		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)\ReadMe.md')">$(MSBuildProjectDirectory)\ReadMe.md</_PackageReadmeFilePath>
+		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)/README.md')">$(MSBuildProjectDirectory)/README.md</_PackageReadmeFilePath>
+		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)/readme.md')">$(MSBuildProjectDirectory)/readme.md</_PackageReadmeFilePath>
+		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)/Readme.md')">$(MSBuildProjectDirectory)/Readme.md</_PackageReadmeFilePath>
+		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND Exists('$(MSBuildProjectDirectory)/ReadMe.md')">$(MSBuildProjectDirectory)/ReadMe.md</_PackageReadmeFilePath>
 
 		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND '$(SearchReadmeFileAbove)' == 'true' AND Exists($([MSBuild]::GetPathOfFileAbove('README.md', '$(MSBuildProjectDirectory)')))">$([MSBuild]::GetPathOfFileAbove('README.md', '$(MSBuildProjectDirectory)'))</_PackageReadmeFilePath>
 		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND '$(SearchReadmeFileAbove)' == 'true' AND Exists($([MSBuild]::GetPathOfFileAbove('readme.md', '$(MSBuildProjectDirectory)')))">$([MSBuild]::GetPathOfFileAbove('readme.md', '$(MSBuildProjectDirectory)'))</_PackageReadmeFilePath>
 		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND '$(SearchReadmeFileAbove)' == 'true' AND Exists($([MSBuild]::GetPathOfFileAbove('Readme.md', '$(MSBuildProjectDirectory)')))">$([MSBuild]::GetPathOfFileAbove('Readme.md', '$(MSBuildProjectDirectory)'))</_PackageReadmeFilePath>
 		<_PackageReadmeFilePath Condition="'$(_PackageReadmeFilePath)' == '' AND '$(SearchReadmeFileAbove)' == 'true' AND Exists($([MSBuild]::GetPathOfFileAbove('ReadMe.md', '$(MSBuildProjectDirectory)')))">$([MSBuild]::GetPathOfFileAbove('ReadMe.md', '$(MSBuildProjectDirectory)'))</_PackageReadmeFilePath>
 
-		<_PackageThirdPartyNoticesPath Condition="Exists('$(MSBuildProjectDirectory)\THIRD-PARTY-NOTICES.TXT')">$(MSBuildProjectDirectory)\THIRD-PARTY-NOTICES.TXT</_PackageThirdPartyNoticesPath>
+		<_PackageThirdPartyNoticesPath Condition="Exists('$(MSBuildProjectDirectory)/THIRD-PARTY-NOTICES.TXT')">$(MSBuildProjectDirectory)/THIRD-PARTY-NOTICES.TXT</_PackageThirdPartyNoticesPath>
 
 		<_LicensePath Condition="Exists($([MSBuild]::GetPathOfFileAbove('LICENSE.txt')))">$([MSBuild]::GetPathOfFileAbove('LICENSE.txt'))</_LicensePath>
 

--- a/src/common/Npm.targets
+++ b/src/common/Npm.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <NpmPackageFile Condition="'$(EnableDefaultNpmPackageFile)' != 'false' AND Exists('$(MSBuildProjectDirectory)\package.json')" Include="$(MSBuildProjectDirectory)\package.json" />
+    <NpmPackageFile Condition="'$(EnableDefaultNpmPackageFile)' != 'false' AND Exists('$(MSBuildProjectDirectory)/package.json')" Include="$(MSBuildProjectDirectory)/package.json" />
   </ItemGroup>
 
   <!-- Compute additional metadata for the NpmPackageFile items -->

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -52,7 +52,7 @@
     <VSTestBlameHangTimeout>10min</VSTestBlameHangTimeout>
 
     <VSTestCollect Condition="'$(EnableCodeCoverage)' == 'true'">Code Coverage</VSTestCollect>
-    <VSTestSetting Condition="'$(EnableCodeCoverage)' == 'true'">$(MSBuildThisFileDirectory)..\configuration\default.runsettings</VSTestSetting>
+    <VSTestSetting Condition="'$(EnableCodeCoverage)' == 'true'">$(MSBuildThisFileDirectory)../configuration/default.runsettings</VSTestSetting>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Why
MSBuild path literals in shared .props and .targets files used backslashes. Normalizing them to forward slashes keeps paths cross-platform friendly and consistent across the SDK files.

## What changed
- Replaced backslash path separators with forward slashes in path literals used by `Import`, `Include`/`Exclude`, property values, and `Exists(...)` checks.
- Updated these files:
  - `src/common/Common.props`
  - `src/common/Common.targets`
  - `src/common/Npm.targets`
  - `src/common/Tests.targets`
- Kept non-path backslashes (for regex and string escaping) unchanged.

## Notes for reviewers
- This is a normalization-only change; target behavior and build logic are unchanged.
- `dotnet build Meziantou.NET.Sdk.slnx` succeeds.
- `dotnet test tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj` hangs in this environment after entering VSTest execution, so I could not complete a full test run here.