### PR TITLE
Add MA0015 test for ThrowIfLessThan member access

### DIFF
--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -534,6 +534,31 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task DefaultEditorConfig_MA0015_DoesNotReportThrowIfLessThanWithMemberAccess()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Sample.cs", """
+            class Options
+            {
+                public int ModuleSize { get; set; }
+            }
+
+            class Sample
+            {
+                public void Test(Options options)
+                {
+                    System.ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleSize, 1, nameof(options.ModuleSize));
+                }
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput(["--configuration", "Debug"]);
+        Assert.False(data.HasWarning("MA0015"));
+        Assert.False(data.HasError("MA0015"));
+    }
+
+    [Fact]
     public async Task NuGetAuditIsReportedAsErrorOnGitHubActions()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
## Why
MA0015 should not report when `ThrowIfLessThan` is used with a member access argument and a matching `nameof(...)` parameter name. This adds a regression test to lock that behavior.

## What changed
- Added `DefaultEditorConfig_MA0015_DoesNotReportThrowIfLessThanWithMemberAccess` in `tests/Meziantou.Sdk.Tests/SdkTests.cs`.
- The test compiles sample code using:
  - `ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleSize, 1, nameof(options.ModuleSize));`
- It asserts that both warning and error `MA0015` are not reported.

## Notes
- The test is added to `SdkTests`, so it runs in the existing SDK variant matrix used by this suite.