### PR TITLE
Update Meziantou.Analyzer and MA0193 configuration

### DIFF
--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -66,7 +66,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.52" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.54" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -40,10 +40,12 @@
 		<Version Condition="'$(_GitHubTagVersionIsValid)' != 'true' AND '$(_IsGitHubMain)' != 'true' AND '$(GITHUB_SHA)' != '' AND '$(_GitHubBaseVersion)' != ''">$(_GitHubBaseVersion)-build-$(GITHUB_SHA)</Version>
 	</PropertyGroup>
 
-  <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'">
-    <PackageReference Include="Meziantou.AspNetCore.ServiceDefaults" Version="1.0.32" IsImplicitlyDefined="true" />
-    <PackageReference Include="Meziantou.AspNetCore.ServiceDefaults.AutoRegister" Version="1.0.2" IsImplicitlyDefined="true" Condition="'$(AutoRegisterServiceDefaults)' != 'false'" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'">
+		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults" Version="1.0.32" IsImplicitlyDefined="true" />
+		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults.AutoRegister" Version="1.0.2" IsImplicitlyDefined="true" Condition="'$(AutoRegisterServiceDefaults)' != 'false'" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" IsImplicitlyDefined="true" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" IsImplicitlyDefined="true" />
+	</ItemGroup>
 
 	<!-- Ensure application can run with newer frameworks -->
 	<PropertyGroup>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -41,10 +41,8 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'">
-		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults" Version="1.0.32" IsImplicitlyDefined="true" />
+		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults" Version="1.0.33" IsImplicitlyDefined="true" />
 		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults.AutoRegister" Version="1.0.2" IsImplicitlyDefined="true" Condition="'$(AutoRegisterServiceDefaults)' != 'false'" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" IsImplicitlyDefined="true" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" IsImplicitlyDefined="true" />
 	</ItemGroup>
 
 	<!-- Ensure application can run with newer frameworks -->

--- a/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
@@ -963,3 +963,8 @@ dotnet_diagnostic.MA0191.severity = none
 # Enabled: False, Severity: suggestion
 dotnet_diagnostic.MA0192.severity = none
 
+# MA0193: Use an overload with a MidpointRounding argument
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0193.md
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MA0193.severity = warning
+

--- a/src/configuration/BannedSymbols.txt
+++ b/src/configuration/BannedSymbols.txt
@@ -35,13 +35,6 @@ M:System.Enum.TryParse(System.Type,System.ReadOnlySpan{System.Char},System.Objec
 M:System.Enum.TryParse``1(System.String,``0@);Use an overload with a ignoreCase argument
 M:System.Enum.TryParse``1(System.ReadOnlySpan{System.Char},``0@);Use an overload with a ignoreCase argument
 
-M:System.Math.Round(System.Decimal);Use an overload with a MidpointRounding argument
-M:System.Math.Round(System.Decimal,System.Int32);Use an overload with a MidpointRounding argument
-M:System.Math.Round(System.Double);Use an overload with a MidpointRounding argument
-M:System.Math.Round(System.Double,System.Int32);Use an overload with a MidpointRounding argument
-M:System.MathF.Round(System.Single);Use an overload with a MidpointRounding argument
-M:System.MathF.Round(System.Single,System.Int32);Use an overload with a MidpointRounding argument
-
 M:System.Globalization.CultureInfo.#ctor(System.String);Use CultureInfo.GetCultureInfo
 
 T:System.Tuple`1;Use System.ValueTuple`1


### PR DESCRIPTION
## Why
This updates the SDK to the latest `Meziantou.Analyzer` ruleset and aligns rounding diagnostics in one place. `MA0193` now covers these APIs, so keeping overlapping banned symbols would create duplicate guidance.

## What changed
- Bumped `Meziantou.Analyzer` from `3.0.52` to `3.0.54` in `src/common/Common.props`.
- Regenerated analyzer editorconfig files via `tools/ConfigFilesGenerator` (notably `Analyzer.Meziantou.Analyzer.editorconfig`).
- Set `dotnet_diagnostic.MA0193.severity = warning`.
- Removed `Math.Round(...)` and `MathF.Round(...)` entries from `src/configuration/BannedSymbols.txt`.

## Notes
The regenerated analyzer editorconfig is mostly mechanical churn from the analyzer version update.