### PR TITLE
Add blog post link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ MSBuild SDK that helps standardize build and quality settings across repositorie
   - Disable Roslyn analyzers to speed up build
 - Relevant NuGet packages based on the project type
 
+Blog post: [Creating a custom MSBuild SDK to reduce boilerplate in dotnet projects](https://www.meziantou.net/creating-a-custom-msbuild-sdk-to-reduce-boilerplate-in-dotnet-projects.htm)
+
 # Usage
 
 ## Method 1


### PR DESCRIPTION
This change adds a direct reference to the companion blog post so readers can quickly find the detailed walkthrough on building a custom MSBuild SDK and reducing .NET project boilerplate.

The README now includes the blog post link in the intro section, before the Usage section. This is a documentation-only update with no code behavior changes.