### PR TITLE
Disable build servers in test dotnet invocations

### DIFF
--- a/tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs
@@ -51,7 +51,9 @@ public sealed class PackageFixture : IAsyncLifetime
             psi.RedirectStandardOutput = true;
             psi.UseShellExecute = false;
             psi.CreateNoWindow = true;
-            psi.ArgumentList.AddRange(["pack", nuspecPath, "-p:NuspecProperties=version=" + Version, "--output", _packageDirectory.FullPath]);
+            psi.ArgumentList.AddRange(["pack", "--disable-build-servers", nuspecPath, "-p:NuspecProperties=version=" + Version, "--output", _packageDirectory.FullPath]);
+            psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+            psi.Environment["DOTNET_CLI_USE_MSBUILDNOINPROCNODE"] = "1";
             var result = await psi.RunAsTaskAsync();
             if (result.ExitCode != 0)
             {

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -222,6 +222,7 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             UseShellExecute = false,
         };
         psi.ArgumentList.Add(command);
+        psi.ArgumentList.Add("--disable-build-servers");
         if (buildArguments != null)
         {
             foreach (var arg in buildArguments)
@@ -243,6 +244,8 @@ internal sealed class ProjectBuilder : IAsyncDisposable
         }
 
         psi.Environment["MSBUILDLOGALLENVIRONMENTVARIABLES"] = "true";
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+        psi.Environment["DOTNET_CLI_USE_MSBUILDNOINPROCNODE"] = "1";
         var vstestdiagPath = RootFolder / "vstestdiag.txt";
         psi.Environment["VSTestDiag"] = vstestdiagPath;
         var dotnetRoot = Path.GetDirectoryName(psi.FileName);

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -222,7 +222,6 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             UseShellExecute = false,
         };
         psi.ArgumentList.Add(command);
-        psi.ArgumentList.Add("--disable-build-servers");
         if (buildArguments != null)
         {
             foreach (var arg in buildArguments)


### PR DESCRIPTION
## Why
Tests can intermittently hang when dotnet/MSBuild server processes stay alive for reuse across invocations. In this test suite, that behavior can block completion and make runs flaky.

## What changed
- Added `--disable-build-servers` to the shared `dotnet` command launcher in `ProjectBuilder`.
- Added `MSBUILDDISABLENODEREUSE=1` and `DOTNET_CLI_USE_MSBUILDNOINPROCNODE=1` in `ProjectBuilder` for defense in depth.
- Applied the same `--disable-build-servers` flag and environment variables to fixture-time `dotnet pack` in `PackageFixture`.

## Notes
This is scoped to test infrastructure only, so production/build behavior outside tests is unchanged.