### PR TITLE
Move NoWarn suppression to targets with DisableDocumentationWarnings property

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Set these properties in your project file or a directory-level props file. Unles
 | `ImplicitUsings` | `enable` | Enables implicit global usings. |
 | `Nullable` | `enable` | Enables nullable reference types. |
 | `GenerateDocumentationFile` | `true` | Generates XML docs. |
+| `EnableDocumentationWarnings` | `false` | When `true`, enables CS1573 and CS1591 warnings for undocumented public members. |
 | `RestoreUseStaticGraphEvaluation` | `true` | Enables static graph restore. |
 | `RestoreSerializeGlobalProperties` | `true` | Serializes global properties for restore. |
 | `ReportAnalyzer` | `true` | Enables analyzer reporting. |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Set these properties in your project file or a directory-level props file. Unles
 | `ImplicitUsings` | `enable` | Enables implicit global usings. |
 | `Nullable` | `enable` | Enables nullable reference types. |
 | `GenerateDocumentationFile` | `true` | Generates XML docs. |
-| `EnableDocumentationWarnings` | `false` | When `true`, enables CS1573 and CS1591 warnings for undocumented public members. |
+| `DisableDocumentationWarnings` | `true` | When `false`, enables CS1573 and CS1591 warnings for undocumented public members. |
 | `RestoreUseStaticGraphEvaluation` | `true` | Enables static graph restore. |
 | `RestoreSerializeGlobalProperties` | `true` | Serializes global properties for restore. |
 | `ReportAnalyzer` | `true` | Enables analyzer reporting. |

--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -29,7 +29,6 @@
     <Nullable>enable</Nullable>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1573;CS1591</NoWarn> <!-- Remove warning for undocumented members -->
 
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
     <RestoreSerializeGlobalProperties>true</RestoreSerializeGlobalProperties>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -10,6 +10,11 @@
     <GenerateSBOM Condition="'$(GenerateSBOM)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">true</GenerateSBOM>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<!-- Suppress documentation warnings (CS1573, CS1591) unless EnableDocumentationWarnings is set to true -->
+		<NoWarn Condition="'$(EnableDocumentationWarnings)' != 'true'">$(NoWarn);CS1573;CS1591</NoWarn>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(_IsGitHubActions)' == 'true' AND '$(UsingMicrosoftNETSdkWeb)' == 'true'">
 		<EnableSdkContainerSupport Condition="'$(EnableSdkContainerSupport)' == ''">true</EnableSdkContainerSupport>
 		<ContainerRegistry Condition="'$(ContainerRegistry)' == ''">ghcr.io</ContainerRegistry>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!-- Suppress documentation warnings (CS1573, CS1591) unless EnableDocumentationWarnings is set to true -->
-		<NoWarn Condition="'$(EnableDocumentationWarnings)' != 'true'">$(NoWarn);CS1573;CS1591</NoWarn>
+		<!-- Suppress documentation warnings (CS1573, CS1591) unless DisableDocumentationWarnings is set to false -->
+		<NoWarn Condition="'$(DisableDocumentationWarnings)' != 'false'">$(NoWarn);CS1573;CS1591</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(_IsGitHubActions)' == 'true' AND '$(UsingMicrosoftNETSdkWeb)' == 'true'">

--- a/tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs
@@ -44,7 +44,7 @@ public sealed class PackageFixture : IAsyncLifetime
         // Build NuGet packages
         var buildFiles = Directory.GetFiles(PathHelpers.GetRootDirectory() / "src", "*.csproj").Select(FullPath.FromPath);
         Assert.NotEmpty(buildFiles);
-        await Parallel.ForEachAsync(buildFiles, async (nuspecPath, _) =>
+        await Parallel.ForEachAsync(buildFiles, async (nuspecPath, ct) =>
         {
             var psi = new ProcessStartInfo("dotnet");
             psi.RedirectStandardError = true;
@@ -54,7 +54,9 @@ public sealed class PackageFixture : IAsyncLifetime
             psi.ArgumentList.AddRange(["pack", "--disable-build-servers", nuspecPath, "-p:NuspecProperties=version=" + Version, "--output", _packageDirectory.FullPath]);
             psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
             psi.Environment["DOTNET_CLI_USE_MSBUILDNOINPROCNODE"] = "1";
-            var result = await psi.RunAsTaskAsync();
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, ct);
+            var result = await psi.RunAsTaskAsync(linkedCts.Token);
             if (result.ExitCode != 0)
             {
                 Assert.Fail($"NuGet pack failed with exit code {result.ExitCode}. Output: {result.Output}");

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -279,7 +279,11 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             TestContext.Current.TestOutputHelper?.WriteLine($"  {env.Key}={env.Value}");
         }
 
-        var result = await psi.RunAsTaskAsync();
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        var result = await psi.RunAsTaskAsync(cancellationToken);
 
         // Retry up to 5 times if MSB4236 or NETSDK1004 error occurs (SDK resolution or assets file issue)
         const int maxRetries = 5;
@@ -294,9 +298,9 @@ internal sealed class ProjectBuilder : IAsyncDisposable
                 _testOutputHelper.WriteLine($"SDK resolution or restore error detected, retrying ({retry + 1}/{maxRetries})...");
 
                 // Exponential backoff: 100ms, 200ms, 400ms, 800ms, 1600ms
-                await Task.Delay(100 * (1 << retry));
+                await Task.Delay(100 * (1 << retry), cancellationToken);
 
-                result = await psi.RunAsTaskAsync();
+                result = await psi.RunAsTaskAsync(cancellationToken);
             }
             else
             {
@@ -378,7 +382,7 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             }
         }
 
-        return psi.RunAsTaskAsync();
+        return psi.RunAsTaskAsync(TestContext.Current.CancellationToken);
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -736,7 +736,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     public async Task DocumentationWarnings_ReportedWhenEnabled()
     {
         await using var project = CreateProjectBuilder();
-        project.AddCsprojFile(properties: [("OutputType", "Library"), ("EnableDocumentationWarnings", "true")]);
+        project.AddCsprojFile(properties: [("OutputType", "Library"), ("DisableDocumentationWarnings", "false")]);
         project.AddFile("Sample.cs", """
             public class Sample
             {

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -713,6 +713,40 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.Contains(outputFiles, f => f.EndsWith(".xml", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task DocumentationWarnings_SuppressedByDefault()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("OutputType", "Library")]);
+        project.AddFile("Sample.cs", """
+            public class Sample
+            {
+                /// <param name="undocumented">Missing param doc triggers CS1573</param>
+                public static void Method(int undocumented, int alsoUndocumented) { }
+
+                public int UndocumentedProperty { get; set; }
+            }
+            """);
+        var data = await project.BuildAndGetOutput();
+        Assert.False(data.HasWarning("CS1573"));
+        Assert.False(data.HasWarning("CS1591"));
+    }
+
+    [Fact]
+    public async Task DocumentationWarnings_ReportedWhenEnabled()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("OutputType", "Library"), ("EnableDocumentationWarnings", "true")]);
+        project.AddFile("Sample.cs", """
+            public class Sample
+            {
+                public int UndocumentedProperty { get; set; }
+            }
+            """);
+        var data = await project.BuildAndGetOutput();
+        Assert.True(data.HasWarning("CS1591"));
+    }
+
     [Theory]
     [InlineData("readme.md")]
     [InlineData("Readme.md")]


### PR DESCRIPTION
The SDK previously suppressed CS1573 and CS1591 (undocumented member warnings) unconditionally in `Common.props`, giving users no way to opt back in.

This PR makes the suppression conditional and late-bound:

- Removes the unconditional `<NoWarn>` from `Common.props`
- Adds it to `Common.targets` behind a `DisableDocumentationWarnings` property (default: `true`)
- Setting `<DisableDocumentationWarnings>false</DisableDocumentationWarnings>` in a project re-enables CS1573 and CS1591

The move to `.targets` is intentional -- targets are evaluated after user props, so the condition correctly responds to user-set values. A props-side condition would be evaluated too early.

Two new tests cover both the default (suppressed) and opt-in (re-enabled) behaviors. A 10-minute `CancellationToken` timeout was also added to all `dotnet` process invocations in the test helpers to prevent tests from hanging indefinitely.

README updated with the new property.