### PR TITLE
Remove LogGitHubActionsMetadata test target

### DIFF
--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -86,21 +86,4 @@
     </When>
   </Choose>
 
-  <!-- Log GitHub Actions metadata before running tests -->
-  <Target Name="LogGitHubActionsMetadata" BeforeTargets="VSTest;_MTPBuild" Condition="'$(_IsGitHubActions)' == 'true'">
-    <PropertyGroup>
-      <_GitHubJobIdEscaped>$(GITHUB_JOB.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_GitHubJobIdEscaped>
-      <_GitHubWorkflowEscaped>$(GITHUB_WORKFLOW.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_GitHubWorkflowEscaped>
-      <_GitHubActionEscaped>$(GITHUB_ACTION.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_GitHubActionEscaped>
-      <_GitHubRunIdEscaped>$(GITHUB_RUN_ID.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_GitHubRunIdEscaped>
-      <_GitHubRunNumberEscaped>$(GITHUB_RUN_NUMBER.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_GitHubRunNumberEscaped>
-      <_GitHubRunAttemptEscaped>$(GITHUB_RUN_ATTEMPT.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_GitHubRunAttemptEscaped>
-      <_RunnerNameEscaped>$(RUNNER_NAME.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_RunnerNameEscaped>
-      <_RunnerOsEscaped>$(RUNNER_OS.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_RunnerOsEscaped>
-      <_RunnerArchEscaped>$(RUNNER_ARCH.Replace('\', '\\').Replace('"', '\"').Replace('$([System.Environment]::NewLine)', '\n'))</_RunnerArchEscaped>
-      <_GitHubMetadataJson>{"github_job_id":"$(_GitHubJobIdEscaped)","github_workflow":"$(_GitHubWorkflowEscaped)","github_action":"$(_GitHubActionEscaped)","github_run_id":"$(_GitHubRunIdEscaped)","github_run_number":"$(_GitHubRunNumberEscaped)","github_run_attempt":"$(_GitHubRunAttemptEscaped)","runner_name":"$(_RunnerNameEscaped)","runner_os":"$(_RunnerOsEscaped)","runner_arch":"$(_RunnerArchEscaped)"}</_GitHubMetadataJson>
-    </PropertyGroup>
-    <Message Text="GitHub Actions Metadata: $(_GitHubMetadataJson)" Importance="high" />
-  </Target>
-
 </Project>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1594,48 +1594,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task GitHubActionsMetadataIsLoggedBeforeTests()
-    {
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. XUnit2References]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Fact]
-                public void Test1()
-                {
-                    Assert.True(true);
-                }
-            }
-            """);
-
-        var environmentVariables = new (string Name, string Value)[]
-        {
-            ("GITHUB_ACTIONS", "true"),
-            ("GITHUB_JOB", "test-job"),
-            ("GITHUB_WORKFLOW", "CI"),
-            ("GITHUB_ACTION", "run-tests"),
-            ("GITHUB_RUN_ID", "123456"),
-            ("GITHUB_RUN_NUMBER", "42"),
-            ("GITHUB_RUN_ATTEMPT", "1"),
-            ("RUNNER_NAME", "GitHub Actions 1"),
-            ("RUNNER_OS", "Linux"),
-            ("RUNNER_ARCH", "X64"),
-            ("GITHUB_STEP_SUMMARY", project.RootFolder / "step_summary.txt")
-        };
-
-        var data = await project.TestAndGetOutput(environmentVariables: environmentVariables);
-        Assert.Equal(0, data.ExitCode);
-
-        var expectedJson = """GitHub Actions Metadata: {"github_job_id":"test-job","github_workflow":"CI","github_action":"run-tests","github_run_id":"123456","github_run_number":"42","github_run_attempt":"1","runner_name":"GitHub Actions 1","runner_os":"Linux","runner_arch":"X64"}""";
-        Assert.True(data.OutputContains(expectedJson, StringComparison.Ordinal));
-    }
-
-    [Fact]
     public async Task GitHubActionsEnvironmentVariablesAreEmbeddedInBinLog()
     {
         await using var project = CreateProjectBuilder();
@@ -1680,31 +1638,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         data.AssertMSBuildPropertyValue("_RunnerName", "Runner-1");
         data.AssertMSBuildPropertyValue("_RunnerOs", "Windows");
         data.AssertMSBuildPropertyValue("_RunnerArch", "X64");
-    }
-
-    [Fact]
-    public async Task GitHubActionsMetadataNotLoggedWhenNotOnGitHub()
-    {
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. XUnit2References]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Fact]
-                public void Test1()
-                {
-                    Assert.True(true);
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput();
-        Assert.Equal(0, data.ExitCode);
-        Assert.False(data.OutputContains("GitHub Actions Metadata:", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
This change removes the GitHub Actions metadata logging hook from test runs. The metadata is already captured in binlogs via existing build targets, so keeping a separate pre-test log target and tests for it adds noise without additional value.

## What changed
- Removed the `LogGitHubActionsMetadata` target from `src/common/Tests.targets`.
- Removed SDK tests that specifically asserted the `GitHub Actions Metadata:` log output.
- Kept the existing binlog embedding test coverage for GitHub Actions environment variables.

## Notes
- `dotnet build Meziantou.NET.Sdk.slnx -v minimal` succeeds in this session.
- `dotnet test` runs in this environment were hanging during test execution, so a full completed test run could not be captured here.