### PR TITLE
Enable warnings-as-errors in AI agent runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Set these properties in your project file or a directory-level props file. Unles
 | `AnalysisLevel` | `latest-all` | Uses the latest analyzer rules. |
 | `AllowUnsafeBlocks` | `true` | Allows `unsafe` code blocks. |
 | `LangVersion` | `latest` | Uses the latest C# language version. |
-| `MSBuildTreatWarningsAsErrors` | `true` on CI or Release | Treats MSBuild warnings as errors. |
-| `TreatWarningsAsErrors` | `true` on CI or Release | Treats compiler warnings as errors. |
+| `MSBuildTreatWarningsAsErrors` | `true` on CI, Release, or AI agent runtime | Treats MSBuild warnings as errors. |
+| `TreatWarningsAsErrors` | `true` on CI, Release, or AI agent runtime | Treats compiler warnings as errors. |
 | `EnforceCodeStyleInBuild` | `true` on CI or Release | Enforces analyzer code style during builds. |
 | `AccelerateBuildsInVisualStudio` | `true` | Enables faster builds in Visual Studio. |
 
@@ -126,7 +126,7 @@ Set these properties in your project file or a directory-level props file. Unles
 | `NuGetAudit` | `true` | Enables NuGet vulnerability auditing. |
 | `NuGetAuditMode` | `all` | Audits all dependency types. |
 | `NuGetAuditLevel` | `low` | Minimum severity level to report. |
-| `WarningsAsErrors` | Adds `NU1900`–`NU1904` on CI or Release | Promotes NuGet audit warnings to errors. |
+| `WarningsAsErrors` | Adds `NU1900`–`NU1904` on CI, Release, or AI agent runtime | Promotes NuGet audit warnings to errors. |
 
 ## Banned symbols and analyzers
 

--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -41,8 +41,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CA1014</NoWarn>
-    <MSBuildTreatWarningsAsErrors Condition="'$(ContinuousIntegrationBuild)' == 'true' OR '$(Configuration)' == 'Release'">true</MSBuildTreatWarningsAsErrors>
-    <TreatWarningsAsErrors Condition="'$(ContinuousIntegrationBuild)' == 'true' OR '$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
+    <_IsAiAgentBuild Condition="'$(GITHUB_COPILOT_RUNTIME)' != '' OR '$(CLAUDECODE)' != '' OR '$(CLAUDE_CODE_ENTRYPOINT)' != '' OR '$(GEMINI_CLI)' != '' OR '$(CODEX_SANDBOX)' != ''">true</_IsAiAgentBuild>
+    <_EnableWarningsAsErrors Condition="'$(ContinuousIntegrationBuild)' == 'true' OR '$(Configuration)' == 'Release' OR '$(_IsAiAgentBuild)' == 'true'">true</_EnableWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors Condition="'$(_EnableWarningsAsErrors)' == 'true'">true</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(_EnableWarningsAsErrors)' == 'true'">true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild Condition="'$(ContinuousIntegrationBuild)' == 'true' OR '$(Configuration)' == 'Release'">true</EnforceCodeStyleInBuild>
 
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
@@ -52,7 +54,7 @@
     <NuGetAudit>true</NuGetAudit>
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>low</NuGetAuditLevel>
-    <WarningsAsErrors Condition="'$(ContinuousIntegrationBuild)' == 'true' OR '$(Configuration)' == 'Release'">$(WarningsAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+    <WarningsAsErrors Condition="'$(_EnableWarningsAsErrors)' == 'true'">$(WarningsAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -347,6 +347,39 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task WarningsAsErrorOnAiAgent()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("sample.cs", """_ = System.DateTime.Now;""");
+        var data = await project.BuildAndGetOutput(environmentVariables: [("CLAUDECODE", "1")]);
+        Assert.True(data.HasError("RS0030"));
+        Assert.NotEqual("true", data.GetMSBuildPropertyValue("ContinuousIntegrationBuild"));
+    }
+
+    [Theory]
+    [InlineData("GITHUB_COPILOT_RUNTIME")]
+    [InlineData("CLAUDECODE")]
+    [InlineData("CLAUDE_CODE_ENTRYPOINT")]
+    [InlineData("GEMINI_CLI")]
+    [InlineData("CODEX_SANDBOX")]
+    public async Task AiAgentEnvironmentVariables_EnableWarningsAsErrors(string environmentVariableName)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("sample.cs", "Console.WriteLine();");
+
+        var data = await project.BuildAndGetOutput(environmentVariables: [(environmentVariableName, "1")]);
+
+        data.AssertMSBuildPropertyValue("_IsAiAgentBuild", "true");
+        data.AssertMSBuildPropertyValue("_EnableWarningsAsErrors", "true");
+        data.AssertMSBuildPropertyValue("MSBuildTreatWarningsAsErrors", "true");
+        data.AssertMSBuildPropertyValue("TreatWarningsAsErrors", "true");
+        Assert.Contains("NU1903", data.GetMSBuildPropertyValue("WarningsAsErrors"), StringComparison.Ordinal);
+        Assert.NotEqual("true", data.GetMSBuildPropertyValue("ContinuousIntegrationBuild"));
+    }
+
+    [Fact]
     public async Task Override_WarningsAsErrors()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
## Why
Warnings are currently escalated to errors on CI or Release builds, but AI agent runs (Copilot, Claude Code, Codex, Gemini CLI) may execute outside CI and miss that strictness. This change keeps warning enforcement consistent for agent-driven builds.

## What changed
- Added AI-agent runtime detection in `src/common/Common.props` using:
  - `GITHUB_COPILOT_RUNTIME`
  - `CLAUDECODE`
  - `CLAUDE_CODE_ENTRYPOINT`
  - `GEMINI_CLI`
  - `CODEX_SANDBOX`
- Introduced a shared internal condition (`_EnableWarningsAsErrors`) that is true for CI, Release, or AI-agent context.
- Applied that condition to:
  - `MSBuildTreatWarningsAsErrors`
  - `TreatWarningsAsErrors`
  - NuGet audit escalation in `WarningsAsErrors` (`NU1900`-`NU1904`)
- Added tests in `tests/Meziantou.Sdk.Tests/SdkTests.cs` to verify AI-agent environment variables enable warning escalation and do not implicitly set `ContinuousIntegrationBuild`.
- Updated README defaults for warning-related properties to include AI-agent runtime behavior.

## Notes
- `ContinuousIntegrationBuild` detection is intentionally unchanged. This is warnings-only behavior to avoid enabling unrelated CI-only features.