### PR TITLE
Remove GitHubActionsTestLogger integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/setup-dotnet@v5
       - run: Get-ChildItem "${{ env.NUGET_DIRECTORY }}/*" -Recurse
       - run: dotnet --info
-      - run: dotnet test tests/Meziantou.Sdk.Tests --logger "trx" --logger GitHubActions --results-directory test_results
+      - run: dotnet test tests/Meziantou.Sdk.Tests --logger "trx" --results-directory test_results
         env:
             NUGET_DIRECTORY: ${{ env.NUGET_DIRECTORY }}
             PACKAGE_VERSION: ${{ needs.compute_version.outputs.package_version }}

--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ Set these properties in your project file or a directory-level props file. Unles
 | `VSTestBlameHangTimeout` | `10min` | Sets hang dump timeout. |
 | `VSTestCollect` | `Code Coverage` when enabled | Enables VSTest code coverage. |
 | `VSTestSetting` | Default runsettings when enabled | Uses the default runsettings file for coverage. |
-| `VSTestLogger` | `trx;console%3bverbosity=normal` | Appends loggers, including GitHub Actions on CI. |
+| `VSTestLogger` | `trx;console%3bverbosity=normal` | Appends loggers. |

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -70,20 +70,4 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
-  <!-- VSTest on GitHub -->
-  <Choose>
-    <When Condition="'$(_IsGitHubActions)' == 'true'">
-      <PropertyGroup>
-        <VSTestLogger>$(VSTestLogger);GitHubActions</VSTestLogger>
-      </PropertyGroup>
-
-      <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" IsImplicitlyDefined="true">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-      </ItemGroup>
-    </When>
-  </Choose>
-
 </Project>

--- a/src/configuration/default.runsettings
+++ b/src/configuration/default.runsettings
@@ -1,19 +1,12 @@
 <RunSettings>
   <RunConfiguration>
-    <TreatNoTestsAsError>true</TreatNoTestsAsError>   
+    <TreatNoTestsAsError>true</TreatNoTestsAsError>
   </RunConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>
       <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
         <Configuration>
           <IncludeTestAssembly>False</IncludeTestAssembly>
-          <CodeCoverage>
-            <ModulePaths>
-              <Exclude>
-                <ModulePath>.*\\GitHubActionsTestLogger.dll$</ModulePath>
-              </Exclude>
-            </ModulePaths>
-          </CodeCoverage>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj
+++ b/tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj
@@ -22,10 +22,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -936,38 +936,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task VSTests_OnGitHubActionsShouldNotAddCustomLogger_Xunit2()
-    {
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. XUnit2References]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Fact]
-                public void Test1()
-                {
-                    Assert.Equal("true", System.Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
-                    Assert.NotEmpty(System.Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY") ?? "");
-                    Assert.Fail("failure message");
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput(environmentVariables: [.. project.GitHubEnvironmentVariables]);
-
-        Assert.Equal(1, data.ExitCode);
-        Assert.True(data.OutputContains("failure message", StringComparison.Ordinal), userMessage: "Output must contain 'failure message'");
-        Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
-        Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.coverage", SearchOption.AllDirectories));
-        Assert.False(data.OutputContains("::error title=Tests.Test1,", StringComparison.Ordinal));
-        Assert.Empty(project.GetGitHubStepSummaryContent());
-    }
-
-    [Fact]
     public async Task VSTests_OnGitHubActionsShouldNotAddCustomLogger_Xunit3()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -936,42 +936,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task VSTests_OnGitHubActionsShouldNotAddCustomLogger_Xunit3()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            Assert.Skip("Failing, need more investigation");
-        }
-
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. XUnit3References]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Fact]
-                public void Test1()
-                {
-                    Assert.Equal("true", System.Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
-                    Assert.NotEmpty(System.Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY") ?? "");
-                    Assert.Fail("failure message");
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput(environmentVariables: [.. project.GitHubEnvironmentVariables]);
-
-        Assert.Equal(1, data.ExitCode);
-        Assert.True(data.OutputContains("failure message", StringComparison.Ordinal));
-        Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
-        Assert.False(data.OutputContains("::error title=Tests.Test1,", StringComparison.Ordinal));
-        Assert.Empty(project.GetGitHubStepSummaryContent());
-    }
-
-    [Fact]
     public async Task VSTests_OnUnknownContextShouldNotAddCustomLogger()
     {
         await using var project = CreateProjectBuilder(SdkTestName);

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -936,7 +936,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task VSTests_OnGitHubActionsShouldAddCustomLogger_Xunit2()
+    public async Task VSTests_OnGitHubActionsShouldNotAddCustomLogger_Xunit2()
     {
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
@@ -963,12 +963,12 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.True(data.OutputContains("failure message", StringComparison.Ordinal), userMessage: "Output must contain 'failure message'");
         Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
         Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.coverage", SearchOption.AllDirectories));
-        Assert.True(data.OutputContains("::error title=Tests.Test1,", StringComparison.Ordinal), userMessage: "Output must contain '::error title=Tests.Test1'");
-        Assert.NotEmpty(project.GetGitHubStepSummaryContent());
+        Assert.False(data.OutputContains("::error title=Tests.Test1,", StringComparison.Ordinal));
+        Assert.Empty(project.GetGitHubStepSummaryContent());
     }
 
     [Fact]
-    public async Task VSTests_OnGitHubActionsShouldAddCustomLogger_Xunit3()
+    public async Task VSTests_OnGitHubActionsShouldNotAddCustomLogger_Xunit3()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -999,8 +999,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.Equal(1, data.ExitCode);
         Assert.True(data.OutputContains("failure message", StringComparison.Ordinal));
         Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
-        Assert.True(data.OutputContains("::error title=Tests.Test1,", StringComparison.Ordinal), userMessage: "Output must contain '::error title=Tests.Test1'");
-        Assert.NotEmpty(project.GetGitHubStepSummaryContent());
+        Assert.False(data.OutputContains("::error title=Tests.Test1,", StringComparison.Ordinal));
+        Assert.Empty(project.GetGitHubStepSummaryContent());
     }
 
     [Fact]


### PR DESCRIPTION
This removes the GitHub Actions-specific VSTest logger integration so test defaults no longer depend on `GitHubActionsTestLogger`.

## Summary
- Remove GitHub Actions logger wiring from `src/common/Tests.targets` (no implicit package reference, no `VSTestLogger += GitHubActions`).
- Remove logger-specific references from supporting files:
  - `tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj`
  - `src/configuration/default.runsettings`
  - `.github/workflows/ci.yml` (`dotnet test` no longer requests `--logger GitHubActions`)
- Update tests and docs to reflect new behavior:
  - `tests/Meziantou.Sdk.Tests/SdkTests.cs`
  - `README.md`

## Notes
- `dotnet build tests/Meziantou.Sdk.Tests` succeeds.
- Targeted `dotnet test` runs in this environment repeatedly hit `TESTRUNABORT` from the Blame hang collector, so full runtime test validation was not completed here.