### PR TITLE
Remove Basic.Reference.Assemblies from ConfigFilesGenerator

### DIFF
--- a/tools/ConfigFilesGenerator/ConfigFilesGenerator.csproj
+++ b/tools/ConfigFilesGenerator/ConfigFilesGenerator.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.7" />
     <PackageReference Include="Meziantou.Framework.DependencyScanning" Version="2.0.14" />
     <PackageReference Include="Meziantou.Framework.FullPath" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />

--- a/tools/ConfigFilesGenerator/Program.cs
+++ b/tools/ConfigFilesGenerator/Program.cs
@@ -199,7 +199,7 @@ async Task GenerateBanSymbolsForNewtonsoftJson()
 
         using var stream = package.PackageReader.GetStream(item);
         var metadataRef = MetadataReference.CreateFromStream(stream);
-        var allRefs = Basic.Reference.Assemblies.Net100.References.All.Add(metadataRef);
+        var allRefs = GetCompilationReferences(metadataRef);
 
         var compilation = CSharpCompilation.Create("temp", syntaxTrees: [], references: allRefs);
         var asm = compilation.GetTypeByMetadataName("Newtonsoft.Json.JsonConvert")!.ContainingAssembly;
@@ -230,6 +230,42 @@ async Task GenerateBanSymbolsForNewtonsoftJson()
     bannedSymbolsFilePath.CreateParentDirectory();
     await File.WriteAllTextAsync(bannedSymbolsFilePath, text);
     Interlocked.Increment(ref writtenFiles);
+}
+
+static MetadataReference[] GetCompilationReferences(MetadataReference metadataReference)
+{
+    var references = new List<MetadataReference>();
+    var referencedAssemblyPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string trustedPlatformAssemblies && !string.IsNullOrEmpty(trustedPlatformAssemblies))
+    {
+        foreach (var assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (referencedAssemblyPaths.Add(assemblyPath))
+            {
+                references.Add(MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+    }
+    else
+    {
+        AddAssemblyReference(typeof(object).Assembly);
+        AddAssemblyReference(typeof(Enumerable).Assembly);
+        AddAssemblyReference(typeof(System.Runtime.GCSettings).Assembly);
+    }
+
+    references.Add(metadataReference);
+    return [.. references];
+
+    void AddAssemblyReference(Assembly assembly)
+    {
+        if (string.IsNullOrEmpty(assembly.Location))
+            return;
+
+        if (!referencedAssemblyPaths.Add(assembly.Location))
+            return;
+
+        references.Add(MetadataReference.CreateFromFile(assembly.Location));
+    }
 }
 
 async Task<(string Id, NuGetVersion Version)[]> GetAllReferencedNuGetPackages()


### PR DESCRIPTION
The generator only used `Basic.Reference.Assemblies.Net100` to provide Roslyn metadata references for `GenerateBanSymbolsForNewtonsoftJson`. Removing that package trims dependencies while keeping the same output behavior.

## What changed
- Removed `Basic.Reference.Assemblies.Net100` from `tools/ConfigFilesGenerator/ConfigFilesGenerator.csproj`.
- Replaced `Basic.Reference.Assemblies.Net100.References.All` usage with runtime metadata references in `tools/ConfigFilesGenerator/Program.cs`.
- Added `GetCompilationReferences(...)` to build references from `TRUSTED_PLATFORM_ASSEMBLIES` when available, with a fallback that includes core runtime assemblies (`typeof(object).Assembly` and related assemblies), then appends the Newtonsoft assembly metadata reference.

## Notes for reviewers
- The namespace discovery logic for `BannedSymbols.NewtonsoftJson.txt` is unchanged; only the source of framework references changed.
- `dotnet build Meziantou.NET.Sdk.slnx` and `dotnet run --project tools/ConfigFilesGenerator/ConfigFilesGenerator.csproj -v minimal` succeeded locally.
- `dotnet test` hangs in this environment when the xUnit adapter starts, so full test completion could not be confirmed here.