### PR TITLE
Default npm restore/install to --ignore-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Set these properties in your project file or a directory-level props file. Unles
 | Property | Default | Description |
 | --- | --- | --- |
 | `EnableDefaultNpmPackageFile` | Enabled when unset | Enables automatic package.json inclusion as `NpmPackageFile` (set to `false` to disable). |
+| `NpmIgnoreScripts` | `true` | Adds `--ignore-scripts` to `npm install` / `npm ci` when `true` (set to `false` to allow lifecycle scripts). |
 | `NpmRestoreLockedMode` | `true` on CI or when `RestoreLockedMode` is `true` | Uses `npm ci` when `true`, otherwise `npm install`. |
 
 ## Testing

--- a/src/common/Npm.targets
+++ b/src/common/Npm.targets
@@ -7,6 +7,7 @@
   <!-- Compute additional metadata for the NpmPackageFile items -->
   <Target Name="ComputeNpmPackageMetadata">
     <PropertyGroup>
+      <NpmIgnoreScripts Condition="'$(NpmIgnoreScripts)' == ''">true</NpmIgnoreScripts>
       <NpmRestoreLockedMode Condition="'$(NpmRestoreLockedMode)' == '' AND ('$(RestoreLockedMode)' == 'true' OR '$(ContinuousIntegrationBuild)' == 'true')">true</NpmRestoreLockedMode>
       <_NpmRestoreCommand Condition="'$(NpmRestoreLockedMode)' != 'true'">install</_NpmRestoreCommand>
       <_NpmRestoreCommand Condition="'$(NpmRestoreLockedMode)' == 'true'">ci</_NpmRestoreCommand>
@@ -18,6 +19,7 @@
         <LockFile>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'package-lock.json'))</LockFile>
         <WorkingDirectory>%(RootDir)%(Directory)</WorkingDirectory>
         <_NpmInstallOptions>--no-fund --no-audit</_NpmInstallOptions>
+        <_NpmInstallOptions Condition="'$(NpmIgnoreScripts)' == 'true'">$(_NpmInstallOptions) --ignore-scripts</_NpmInstallOptions>
 
         <InstallCommand>npm install $(_NpmInstallOptions)</InstallCommand>
         <RestoreCommand>npm $(_NpmRestoreCommand) $(_NpmInstallOptions)</RestoreCommand>


### PR DESCRIPTION
## Why
Running npm lifecycle scripts during restore can execute package hooks unexpectedly in build environments. This change makes restore/install safer by default while keeping an explicit opt-out.

## What changed
- Added a new MSBuild property: `NpmIgnoreScripts` (defaults to `true` when unset).
- Appended `--ignore-scripts` to npm options when `NpmIgnoreScripts` is `true`.
- Reused the same options path for both `npm install` and `npm ci` restore flows.
- Documented `NpmIgnoreScripts` in the README npm restore property table.

## Notes
Set `NpmIgnoreScripts=false` to allow npm lifecycle scripts.