### PR TITLE
Harden NuGet PackageReference assets before restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,25 @@ Set these properties in your project file or a directory-level props file. Unles
 | `NuGetAuditMode` | `all` | Audits all dependency types. |
 | `NuGetAuditLevel` | `low` | Minimum severity level to report. |
 | `WarningsAsErrors` | Adds `NU1900`–`NU1904` on CI, Release, or AI agent runtime | Promotes NuGet audit warnings to errors. |
+| `EnablePackageReferenceHardening` | `true` | Excludes `build`, `buildTransitive`, and `analyzers` assets for non-trusted packages before restore. |
+
+## Package reference hardening
+
+By default, package references are considered trusted when their package ID matches one of these patterns:
+
+- `Microsoft.*`
+- `System.*`
+- `Meziantou.*`
+- `xunit`
+- `xunit.*`
+
+For package references outside this allowlist, the SDK appends `build;buildTransitive;analyzers` to `ExcludeAssets` before `CollectPackageReferences`.
+
+You can mark a specific package as trusted using `MeziantouSafePackage="true"`:
+
+```xml
+<PackageReference Include="Some.Package" Version="1.2.3" MeziantouSafePackage="true" />
+```
 
 ## Banned symbols and analyzers
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,10 @@ By default, package references are considered trusted when their package ID matc
 - `Meziantou.*`
 - `xunit`
 - `xunit.*`
+- `TUnit`
+- `TUnit.*`
 
-For package references outside this allowlist, the SDK appends `build;buildTransitive;analyzers` to `ExcludeAssets` before `CollectPackageReferences`.
+For package references outside this allowlist, the SDK appends `build;buildTransitive;analyzers` to `ExcludeAssets` during restore.
 
 You can mark a specific package as trusted using `MeziantouSafePackage="true"`:
 

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -47,7 +47,7 @@
 
 	<ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'">
 		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults" Version="1.0.38" IsImplicitlyDefined="true" />
-		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults.AutoRegister" Version="1.0.3" IsImplicitlyDefined="true" Condition="'$(AutoRegisterServiceDefaults)' != 'false'" />
+		<PackageReference Include="Meziantou.AspNetCore.ServiceDefaults.AutoRegister" Version="1.0.3" IsImplicitlyDefined="true" MeziantouSafePackage="true" Condition="'$(AutoRegisterServiceDefaults)' != 'false'" />
 	</ItemGroup>
 
 	<!-- Ensure application can run with newer frameworks -->
@@ -117,21 +117,24 @@
 	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="CollectPackageReferences" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
 		<ItemGroup>
 			<_UntrustedPackageReference Include="@(PackageReference)"
-			                          Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.MeziantouSafePackage)', '^true$', System.Text.RegularExpressions.RegexOptions.IgnoreCase))
-			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.Identity)', '^(?:(?:Microsoft|System|Meziantou)\.|xunit(?:\.|$))', System.Text.RegularExpressions.RegexOptions.IgnoreCase))" />
+			                          Condition="'$([System.String]::Copy('%(PackageReference.MeziantouSafePackage)').ToLowerInvariant())' != 'true'
+			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy('%(PackageReference.Identity)').ToLowerInvariant())', '^(?:(?:microsoft|system|meziantou)\.|xunit(?:\.|$))'))" />
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
-			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', ';build;', System.Text.RegularExpressions.RegexOptions.IgnoreCase))">
+			                  IsImplicitlyDefined="true"
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy(';%(PackageReference.ExcludeAssets);').ToLowerInvariant())', ';build;'))">
 				<ExcludeAssets>%(PackageReference.ExcludeAssets);build</ExcludeAssets>
 			</PackageReference>
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
-			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', ';buildTransitive;', System.Text.RegularExpressions.RegexOptions.IgnoreCase))">
+			                  IsImplicitlyDefined="true"
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy(';%(PackageReference.ExcludeAssets);').ToLowerInvariant())', ';buildtransitive;'))">
 				<ExcludeAssets>%(PackageReference.ExcludeAssets);buildTransitive</ExcludeAssets>
 			</PackageReference>
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
-			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', ';analyzers;', System.Text.RegularExpressions.RegexOptions.IgnoreCase))">
+			                  IsImplicitlyDefined="true"
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy(';%(PackageReference.ExcludeAssets);').ToLowerInvariant())', ';analyzers;'))">
 				<ExcludeAssets>%(PackageReference.ExcludeAssets);analyzers</ExcludeAssets>
 			</PackageReference>
 		</ItemGroup>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -114,11 +114,11 @@
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="CollectPackageReferences" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
+	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="Restore" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
 		<ItemGroup>
 			<_UntrustedPackageReference Include="@(PackageReference)"
 			                          Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.MeziantouSafePackage)', '(?i)^true$'))
-			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.Identity)', '(?i)^(?:(?:microsoft|system|meziantou)\.|xunit(?:\.|$))'))" />
+			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.Identity)', '(?i)^(?:(?:microsoft|system|meziantou|xunit|tunit)(?:\.|$))'))" />
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
 			                  IsImplicitlyDefined="true"

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -117,7 +117,7 @@
 	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="CollectPackageReferences" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
 		<ItemGroup>
 			<_UntrustedPackageReference Include="@(PackageReference)"
-			                          Condition="'$([System.String]::Copy('%(PackageReference.MeziantouSafePackage)').ToLowerInvariant())' != 'true'
+			                          Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.MeziantouSafePackage)', '^true$', System.Text.RegularExpressions.RegexOptions.IgnoreCase))
 			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.Identity)', '^(?:(?:Microsoft|System|Meziantou)\.|xunit(?:\.|$))', System.Text.RegularExpressions.RegexOptions.IgnoreCase))" />
 
 			<PackageReference Update="@(_UntrustedPackageReference)"

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -114,7 +114,7 @@
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="Restore" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
+	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="CollectPackageReferences" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
 		<ItemGroup>
 			<_UntrustedPackageReference Include="@(PackageReference)"
 			                          Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.MeziantouSafePackage)', '(?i)^true$'))

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -117,24 +117,24 @@
 	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="CollectPackageReferences" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
 		<ItemGroup>
 			<_UntrustedPackageReference Include="@(PackageReference)"
-			                          Condition="'$([System.String]::Copy('%(PackageReference.MeziantouSafePackage)').ToLowerInvariant())' != 'true'
-			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy('%(PackageReference.Identity)').ToLowerInvariant())', '^(?:(?:microsoft|system|meziantou)\.|xunit(?:\.|$))'))" />
+			                          Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.MeziantouSafePackage)', '(?i)^true$'))
+			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.Identity)', '(?i)^(?:(?:microsoft|system|meziantou)\.|xunit(?:\.|$))'))" />
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
 			                  IsImplicitlyDefined="true"
-			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy(';%(PackageReference.ExcludeAssets);').ToLowerInvariant())', ';build;'))">
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', '(?i);build;'))">
 				<ExcludeAssets>%(PackageReference.ExcludeAssets);build</ExcludeAssets>
 			</PackageReference>
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
 			                  IsImplicitlyDefined="true"
-			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy(';%(PackageReference.ExcludeAssets);').ToLowerInvariant())', ';buildtransitive;'))">
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', '(?i);buildtransitive;'))">
 				<ExcludeAssets>%(PackageReference.ExcludeAssets);buildTransitive</ExcludeAssets>
 			</PackageReference>
 
 			<PackageReference Update="@(_UntrustedPackageReference)"
 			                  IsImplicitlyDefined="true"
-			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$([System.String]::Copy(';%(PackageReference.ExcludeAssets);').ToLowerInvariant())', ';analyzers;'))">
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', '(?i);analyzers;'))">
 				<ExcludeAssets>%(PackageReference.ExcludeAssets);analyzers</ExcludeAssets>
 			</PackageReference>
 		</ItemGroup>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -59,6 +59,10 @@
 		<PackAsTool Condition="'$(PackAsTool)' == '' AND '$(OutputType)' == 'Exe' AND '$(IsTestProject)' != 'true'">true</PackAsTool>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<EnablePackageReferenceHardening Condition="'$(EnablePackageReferenceHardening)' == ''">true</EnablePackageReferenceHardening>
+	</PropertyGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>Meziantou.Sdk.Name</_Parameter1>
@@ -108,6 +112,29 @@
 			<_RunnerOs>$(RUNNER_OS)</_RunnerOs>
 			<_RunnerArch>$(RUNNER_ARCH)</_RunnerArch>
 		</PropertyGroup>
+	</Target>
+
+	<Target Name="MeziantouHardenPackageReferenceAssets" BeforeTargets="CollectPackageReferences" Condition="'$(EnablePackageReferenceHardening)' == 'true'">
+		<ItemGroup>
+			<_UntrustedPackageReference Include="@(PackageReference)"
+			                          Condition="'$([System.String]::Copy('%(PackageReference.MeziantouSafePackage)').ToLowerInvariant())' != 'true'
+			                                   AND !$([System.Text.RegularExpressions.Regex]::IsMatch('%(PackageReference.Identity)', '^(?:(?:Microsoft|System|Meziantou)\.|xunit(?:\.|$))', System.Text.RegularExpressions.RegexOptions.IgnoreCase))" />
+
+			<PackageReference Update="@(_UntrustedPackageReference)"
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', ';build;', System.Text.RegularExpressions.RegexOptions.IgnoreCase))">
+				<ExcludeAssets>%(PackageReference.ExcludeAssets);build</ExcludeAssets>
+			</PackageReference>
+
+			<PackageReference Update="@(_UntrustedPackageReference)"
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', ';buildTransitive;', System.Text.RegularExpressions.RegexOptions.IgnoreCase))">
+				<ExcludeAssets>%(PackageReference.ExcludeAssets);buildTransitive</ExcludeAssets>
+			</PackageReference>
+
+			<PackageReference Update="@(_UntrustedPackageReference)"
+			                  Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(';%(PackageReference.ExcludeAssets);', ';analyzers;', System.Text.RegularExpressions.RegexOptions.IgnoreCase))">
+				<ExcludeAssets>%(PackageReference.ExcludeAssets);analyzers</ExcludeAssets>
+			</PackageReference>
+		</ItemGroup>
 	</Target>
 
 	<!-- Disable packages -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -53,6 +53,25 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         return builder;
     }
 
+    private static XElement CreateReportPackageReferenceExcludeAssetsTarget()
+    {
+        return new XElement("Target",
+            new XAttribute("Name", "ReportPackageReferenceExcludeAssets"),
+            new XAttribute("AfterTargets", "MeziantouHardenPackageReferenceAssets"),
+            new XAttribute("BeforeTargets", "CollectPackageReferences"),
+            new XElement("Message",
+                new XAttribute("Importance", "high"),
+                new XAttribute("Text", "MEZIANTOU_PACKAGE_REFERENCE:%(PackageReference.Identity)|%(PackageReference.ExcludeAssets)")));
+    }
+
+    private static string GetPackageReferenceExcludeAssets(BuildResult buildResult, string packageId)
+    {
+        var prefix = $"MEZIANTOU_PACKAGE_REFERENCE:{packageId}|";
+        var line = Assert.Single(buildResult.OutputLines.Where(line => line.Contains(prefix, StringComparison.Ordinal)));
+        var startIndex = line.IndexOf(prefix, StringComparison.Ordinal);
+        return line[(startIndex + prefix.Length)..];
+    }
+
     [Fact]
     public void PackageReferenceAreValid()
     {
@@ -100,6 +119,64 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         project.AddCsprojFile();
         var data = await project.BuildAndGetOutput();
         data.AssertMSBuildPropertyValue("RollForward", expectedValue: null);
+    }
+
+    [Fact]
+    public async Task PackageReferenceHardening_AddsExcludedAssetsForUntrustedPackages()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(
+            nuGetPackages: [new NuGetReference("Newtonsoft.Json", "13.0.4")],
+            additionalProjectElements: [CreateReportPackageReferenceExcludeAssetsTarget()]);
+
+        var data = await project.RestoreAndGetOutput();
+
+        Assert.True(data.IsMSBuildTargetExecuted("MeziantouHardenPackageReferenceAssets"));
+        var excludeAssets = GetPackageReferenceExcludeAssets(data, "Newtonsoft.Json");
+        Assert.Contains("build", excludeAssets, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("buildTransitive", excludeAssets, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("analyzers", excludeAssets, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("System.Text.Json", "9.0.0")]
+    [InlineData("xunit", "2.9.3")]
+    [InlineData("xunit.runner.visualstudio", "3.1.5")]
+    public async Task PackageReferenceHardening_DoesNotChangeTrustedPackages(string packageId, string packageVersion)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(
+            nuGetPackages: [new NuGetReference(packageId, packageVersion)],
+            additionalProjectElements: [CreateReportPackageReferenceExcludeAssetsTarget()]);
+
+        var data = await project.RestoreAndGetOutput();
+
+        var excludeAssets = GetPackageReferenceExcludeAssets(data, packageId);
+        Assert.DoesNotContain("build", excludeAssets, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("buildTransitive", excludeAssets, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("analyzers", excludeAssets, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PackageReferenceHardening_CanBeBypassedUsingSafePackageMetadata()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup",
+                new XElement("PackageReference",
+                    new XAttribute("Include", "Newtonsoft.Json"),
+                    new XAttribute("Version", "13.0.4"),
+                    new XAttribute("MeziantouSafePackage", "true"))),
+            CreateReportPackageReferenceExcludeAssetsTarget(),
+        ]);
+
+        var data = await project.RestoreAndGetOutput();
+
+        var excludeAssets = GetPackageReferenceExcludeAssets(data, "Newtonsoft.Json");
+        Assert.DoesNotContain("build", excludeAssets, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("buildTransitive", excludeAssets, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("analyzers", excludeAssets, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -140,6 +140,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
 
     [Theory]
     [InlineData("System.Text.Json", "9.0.0")]
+    [InlineData("TUnit", "1.22.19")]
     [InlineData("xunit", "2.9.3")]
     [InlineData("xunit.runner.visualstudio", "3.1.5")]
     public async Task PackageReferenceHardening_DoesNotChangeTrustedPackages(string packageId, string packageVersion)


### PR DESCRIPTION
## Why
NuGet package assets such as `build`, `buildTransitive`, and `analyzers` can execute or influence builds in unexpected ways. This change makes package asset behavior secure-by-default while keeping explicit escape hatches for trusted packages.

## What changed
- Added `MeziantouHardenPackageReferenceAssets` in `src/common/Common.targets` with `BeforeTargets="CollectPackageReferences"`.
- Added `EnablePackageReferenceHardening` (default: `true`).
- For non-trusted packages, the target adds `build`, `buildTransitive`, and `analyzers` to `ExcludeAssets`.
- Added built-in trusted package allowlist by package id pattern:
  - `Microsoft.*`
  - `System.*`
  - `Meziantou.*`
  - `xunit`
  - `xunit.*`
- Added per-package override via `MeziantouSafePackage="true"`.
- Made exclusions idempotent so repeated target execution does not keep appending duplicate assets.
- Added tests in `tests/Meziantou.Sdk.Tests/SdkTests.cs` for:
  - hardening of untrusted packages,
  - allowlisted package behavior,
  - per-package safe override,
  - target execution in restore flow.
- Documented the new property and metadata in `README.md`.

## Notes for reviewers
This intentionally applies before NuGet collects package references so restore/build-time assets are constrained as early as possible.

## Validation
- `dotnet pack src/Meziantou.NET.Sdk.csproj --nologo -v minimal`
- `dotnet build tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj --nologo -v minimal`
- Local targeted `dotnet test` runs for the new integration tests were attempted but repeatedly hung in this environment (testhost timeout/abort).