### PR TITLE
Fix package folder layout for shared SDK assets

### DIFF
--- a/src/Meziantou.NET.Sdk.BlazorWebAssembly.nuspec
+++ b/src/Meziantou.NET.Sdk.BlazorWebAssembly.nuspec
@@ -13,8 +13,8 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.BlazorWebAssembly/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.BlazorWebAssembly/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
+    <file src="common/**/*" target="common" />
+    <file src="configuration/**/*" target="configuration" />
     <file src="icon.png" target="" />
     <file src="icon.svg" target="" />
     <file src="../LICENSE.txt" target="" />

--- a/src/Meziantou.NET.Sdk.Razor.nuspec
+++ b/src/Meziantou.NET.Sdk.Razor.nuspec
@@ -13,8 +13,8 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.Razor/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.Razor/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
+    <file src="common/**/*" target="common" />
+    <file src="configuration/**/*" target="configuration" />
     <file src="icon.png" target="" />
     <file src="icon.svg" target="" />
     <file src="../LICENSE.txt" target="" />

--- a/src/Meziantou.NET.Sdk.Test.nuspec
+++ b/src/Meziantou.NET.Sdk.Test.nuspec
@@ -13,8 +13,8 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.Test/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.Test/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
+    <file src="common/**/*" target="common" />
+    <file src="configuration/**/*" target="configuration" />
     <file src="icon.png" target="" />
     <file src="icon.svg" target="" />
     <file src="../LICENSE.txt" target="" />

--- a/src/Meziantou.NET.Sdk.Web.nuspec
+++ b/src/Meziantou.NET.Sdk.Web.nuspec
@@ -13,8 +13,8 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.Web/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.Web/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
+    <file src="common/**/*" target="common" />
+    <file src="configuration/**/*" target="configuration" />
     <file src="icon.png" target="" />
     <file src="icon.svg" target="" />
     <file src="../LICENSE.txt" target="" />

--- a/src/Meziantou.NET.Sdk.WindowsDesktop.nuspec
+++ b/src/Meziantou.NET.Sdk.WindowsDesktop.nuspec
@@ -13,8 +13,8 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.WindowsDesktop/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.WindowsDesktop/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
+    <file src="common/**/*" target="common" />
+    <file src="configuration/**/*" target="configuration" />
     <file src="icon.png" target="" />
     <file src="icon.svg" target="" />
     <file src="../LICENSE.txt" target="" />

--- a/src/Meziantou.NET.Sdk.nuspec
+++ b/src/Meziantou.NET.Sdk.nuspec
@@ -13,8 +13,8 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
+    <file src="common/**/*" target="common" />
+    <file src="configuration/**/*" target="configuration" />
     <file src="icon.png" target="" />
     <file src="icon.svg" target="" />
     <file src="../LICENSE.txt" target="" />

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -71,6 +71,23 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public void PackageLayoutIsValid()
+    {
+        var packages = Directory.GetFiles(fixture.PackageDirectory, "*.nupkg");
+        Assert.NotEmpty(packages);
+
+        foreach (var package in packages)
+        {
+            using var packageReader = new PackageArchiveReader(package);
+            var files = packageReader.GetFiles();
+            Assert.Contains("common/Common.props", files);
+            Assert.Contains("configuration/CodingStyle.editorconfig", files);
+            Assert.DoesNotContain("Common.props", files);
+            Assert.DoesNotContain("CodingStyle.editorconfig", files);
+        }
+    }
+
+    [Fact]
     public async Task ValidateDefaultProperties()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
## Summary
- Place `common` and `configuration` assets under their own top-level folders in all SDK nuspecs
- Add a regression test to verify packaged assets keep the expected directory layout

## Testing
- Added package layout validation coverage in `SdkTests`
- Existing package test suite should cover the updated nuspec structure