### PR TITLE
Stop updating the branch automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,6 @@ jobs:
 
           Write-Error "git diff failed with exit code $LASTEXITCODE"
           exit $LASTEXITCODE
-      - name: Commit and push changes
-        if: steps.check_changes.outputs.has_changes == 'true' && github.repository == 'meziantou/Meziantou.NET.Sdk'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "Update configuration files"
-          git push
       - name: Fail if there are changes
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |


### PR DESCRIPTION
This change makes the config-file validation job stop at detection instead of auto-committing and pushing generated updates from CI.

When the generator produces changes, the workflow now fails and tells contributors to regenerate the files locally and commit them themselves. That keeps CI from mutating the branch while still enforcing that generated config stays current.