### PR TITLE
Disable MA0110 for netstandard2.0 multi-target projects

### DIFF
--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -71,6 +71,11 @@
 		<AdditionalFiles Include="$(MSBuildThisFileDirectory)../configuration/BannedSymbols.NewtonsoftJson.txt" Condition="'$(BannedNewtonsoftJsonSymbols)' != 'false'" Visible="false" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EditorConfigFiles Include="$(MSBuildThisFileDirectory)../configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig"
+		                   Condition="'$(TargetFrameworks)' != '' AND $([System.Text.RegularExpressions.Regex]::IsMatch($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '\s+', '')), '^(?=.*;)(?=.*(?:^|;)netstandard2\.0(?:$|;)).+$'))" />
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
 		<Using Include="System.Diagnostics.CodeAnalysis" />
 		<Using Include="System.Globalization" />

--- a/src/configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig
+++ b/src/configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig
@@ -1,0 +1,6 @@
+# global_level must be higher than the base editorconfig files
+is_global = true
+global_level = 1
+
+# MA0110: Use the Regex source generator
+dotnet_diagnostic.MA0110.severity = none

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -191,6 +191,25 @@ internal sealed class ProjectBuilder : IAsyncDisposable
 
         _buildCount++;
 
+        FullPath sarifPath = _directory.FullPath / SarifFileName;
+        FullPath binlogPath = _directory.FullPath / "msbuild.binlog";
+        FullPath vstestdiagPath = RootFolder / "vstestdiag.txt";
+
+        if (File.Exists(sarifPath))
+        {
+            File.Delete(sarifPath);
+        }
+
+        if (File.Exists(binlogPath))
+        {
+            File.Delete(binlogPath);
+        }
+
+        if (File.Exists(vstestdiagPath))
+        {
+            File.Delete(vstestdiagPath);
+        }
+
         foreach (var file in Directory.GetFiles(_directory.FullPath, "*", SearchOption.AllDirectories))
         {
             _testOutputHelper.WriteLine("File: " + file);
@@ -265,7 +284,6 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             environmentChanges[key] = string.Empty;
         }
 
-        var vstestdiagPath = RootFolder / "vstestdiag.txt";
         environmentChanges["VSTestDiag"] = vstestdiagPath;
         var dotnetRoot = Path.GetDirectoryName(dotnetPath) ?? throw new InvalidOperationException("Cannot get dotnet root path");
         environmentChanges["DOTNET_ROOT"] = dotnetRoot;
@@ -381,7 +399,6 @@ internal sealed class ProjectBuilder : IAsyncDisposable
         _testOutputHelper.WriteLine("Process exit code: " + result.ExitCode);
         _testOutputHelper.WriteLine(result.Output.ToString());
 
-        FullPath sarifPath = _directory.FullPath / SarifFileName;
         SarifFile? sarif = null;
         if (File.Exists(sarifPath))
         {
@@ -394,7 +411,7 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             _testOutputHelper.WriteLine("Sarif file not found: " + sarifPath);
         }
 
-        var binlogContent = File.ReadAllBytes(_directory.FullPath / "msbuild.binlog");
+        var binlogContent = File.ReadAllBytes(binlogPath);
         TestContext.Current.AddAttachment($"msbuild{_buildCount}.binlog", binlogContent);
 
         string? vstestDiagContent = null;

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -326,6 +326,49 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task NetStandard20MultiTargetEditorConfig_IncludedAndDisablesMA0110()
+    {
+        var commonPropsPath = PathHelpers.GetRootDirectory() / "src" / "common" / "Common.props";
+        var commonTargetsPath = PathHelpers.GetRootDirectory() / "src" / "common" / "Common.targets";
+
+        await using var project = CreateProjectBuilder("Microsoft.NET.Sdk");
+        project.AddDirectoryBuildPropsFile($"""<Import Project="{commonPropsPath}" />""");
+        project.AddFile("Sample.cs", """
+            using System.Text.RegularExpressions;
+
+            public static class Sample
+            {
+                public static Regex Create() => new("sample", RegexOptions.Compiled);
+            }
+            """);
+
+        void AddProjectFile(params (string Name, string Value)[] properties)
+        {
+            project.AddCsprojFile(properties: properties, additionalProjectElements:
+            [
+                new XElement("Import", new XAttribute("Project", commonTargetsPath)),
+            ]);
+        }
+
+        AddProjectFile(
+            ("TargetFramework", "net10.0"),
+            ("OutputType", "Library"));
+
+        var singleTargetData = await project.BuildAndGetOutput();
+        Assert.True(singleTargetData.HasNote("MA0110"));
+
+        AddProjectFile(
+            ("TargetFrameworks", "net10.0;netstandard2.0"),
+            ("OutputType", "Library"));
+
+        var multiTargetData = await project.BuildAndGetOutput();
+        var editorConfigFiles = multiTargetData.GetMSBuildItems("EditorConfigFiles");
+
+        Assert.Contains(editorConfigFiles, f => f.EndsWith("Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig", StringComparison.Ordinal));
+        Assert.False(multiTargetData.HasNote("MA0110"));
+    }
+
+    [Fact]
     public async Task WarningsAsErrorOnGitHubActions()
     {
         await using var project = CreateProjectBuilder();

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -361,8 +361,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
             ("TargetFrameworks", "net10.0;netstandard2.0"),
             ("OutputType", "Library"));
 
-        var multiTargetData = await project.BuildAndGetOutput();
-        var editorConfigFiles = multiTargetData.GetMSBuildItems("EditorConfigFiles");
+        var multiTargetData = await project.BuildAndGetOutput(["-p:TargetFramework=netstandard2.0"]);
+        var editorConfigFiles = multiTargetData.GetBinLogFiles();
 
         Assert.Contains(editorConfigFiles, f => f.EndsWith("Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig", StringComparison.Ordinal));
         Assert.False(multiTargetData.HasNote("MA0110"));


### PR DESCRIPTION
Projects that multi-target `netstandard2.0` alongside a modern target cannot use the Regex source generator on the `netstandard2.0` leg, so the default `MA0110` suggestion is noisy there. This adds a targeted editorconfig override so the rule is suppressed only for that multi-target case.

## What changed

- add `Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig` with `MA0110` disabled
- include that editorconfig only when `TargetFrameworks` contains `netstandard2.0` and at least one other target framework
- add a regression test that verifies `MA0110` is still reported for single-target `net10.0`, but not for `net10.0;netstandard2.0`

## Notes

The conditional include lives in `Common.targets` instead of `Common.props` so it evaluates after `TargetFrameworks` is available for the project.