### PR TITLE
Block YamlDotNet and CliWrap package usage in the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,16 @@ Set these properties in your project file or a directory-level props file. Unles
 
 ## Banned symbols and analyzers
 
+The SDK also blocks selected NuGet packages by default:
+- `YamlDotNet` (use `Meziantou.Framework.Yaml`)
+- `CliWrap` (use `Meziantou.Framework.ProcessWrapper`)
+
 | Property | Default | Description |
 | --- | --- | --- |
 | `IncludeDefaultBannedSymbols` | `true` | Includes the default banned API list. |
 | `BannedNewtonsoftJsonSymbols` | `true` | Includes banned Newtonsoft.Json APIs. |
+| `AllowPackage_YamlDotNet` | unset (`false`) | Allows `YamlDotNet` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.Yaml`. |
+| `AllowPackage_CliWrap` | unset (`false`) | Allows `CliWrap` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.ProcessWrapper`. |
 | `Disable_SponsorLink` | `true` | Removes SponsorLink and Moq analyzers when not set to `false`. |
 
 ## Web SDK and containers

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -123,6 +123,25 @@
 		</ItemGroup>
 	</Target>
 
+	<ItemGroup>
+		<BannedPackageReference Include="YamlDotNet" SuggestedPackage="Meziantou.Framework.Yaml" AllowPropertyName="AllowPackage_YamlDotNet" Condition="'$(AllowPackage_YamlDotNet)' != 'true'" />
+		<BannedPackageReference Include="CliWrap" SuggestedPackage="Meziantou.Framework.ProcessWrapper" AllowPropertyName="AllowPackage_CliWrap" Condition="'$(AllowPackage_CliWrap)' != 'true'" />
+	</ItemGroup>
+
+	<Target Name="FailOnBannedPackageReferences" AfterTargets="ResolveReferences" BeforeTargets="CoreCompile">
+		<ItemGroup>
+			<_DetectedBannedPackageReference Include="@(BannedPackageReference)" Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '%(BannedPackageReference.Identity)')) == 'true'" />
+			<_DetectedBannedPackageReference Include="@(BannedPackageReference)" Condition="@(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', '%(BannedPackageReference.Identity)')) == 'true'" />
+		</ItemGroup>
+
+		<RemoveDuplicates Inputs="@(_DetectedBannedPackageReference)">
+			<Output TaskParameter="Filtered" ItemName="_UniqueDetectedBannedPackageReference" />
+		</RemoveDuplicates>
+
+		<Error Text="Package '%(_UniqueDetectedBannedPackageReference.Identity)' is not allowed. Use '%(_UniqueDetectedBannedPackageReference.SuggestedPackage)' instead. To allow this package, set '%(_UniqueDetectedBannedPackageReference.AllowPropertyName)=true'."
+		       Condition="'@(_UniqueDetectedBannedPackageReference)' != ''" />
+	</Target>
+
 	<!-- NuGet Package -->
 	<Choose>
 		<When Condition="'$(PackageIcon)' == '' AND '$(_IsMeziantouProject)' == 'true'">

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -123,23 +123,11 @@
 		</ItemGroup>
 	</Target>
 
-	<ItemGroup>
-		<BannedPackageReference Include="YamlDotNet" SuggestedPackage="Meziantou.Framework.Yaml" AllowPropertyName="AllowPackage_YamlDotNet" Condition="'$(AllowPackage_YamlDotNet)' != 'true'" />
-		<BannedPackageReference Include="CliWrap" SuggestedPackage="Meziantou.Framework.ProcessWrapper" AllowPropertyName="AllowPackage_CliWrap" Condition="'$(AllowPackage_CliWrap)' != 'true'" />
-	</ItemGroup>
-
 	<Target Name="FailOnBannedPackageReferences" AfterTargets="ResolveReferences" BeforeTargets="CoreCompile">
-		<ItemGroup>
-			<_DetectedBannedPackageReference Include="@(BannedPackageReference)" Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '%(BannedPackageReference.Identity)')) == 'true'" />
-			<_DetectedBannedPackageReference Include="@(BannedPackageReference)" Condition="@(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', '%(BannedPackageReference.Identity)')) == 'true'" />
-		</ItemGroup>
-
-		<RemoveDuplicates Inputs="@(_DetectedBannedPackageReference)">
-			<Output TaskParameter="Filtered" ItemName="_UniqueDetectedBannedPackageReference" />
-		</RemoveDuplicates>
-
-		<Error Text="Package '%(_UniqueDetectedBannedPackageReference.Identity)' is not allowed. Use '%(_UniqueDetectedBannedPackageReference.SuggestedPackage)' instead. To allow this package, set '%(_UniqueDetectedBannedPackageReference.AllowPropertyName)=true'."
-		       Condition="'@(_UniqueDetectedBannedPackageReference)' != ''" />
+		<Error Text="Package 'YamlDotNet' is not allowed. Use 'Meziantou.Framework.Yaml' instead. To allow this package, set 'AllowPackage_YamlDotNet=true'."
+		       Condition="'$(AllowPackage_YamlDotNet)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'YamlDotNet')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'YamlDotNet')) == 'true')" />
+		<Error Text="Package 'CliWrap' is not allowed. Use 'Meziantou.Framework.ProcessWrapper' instead. To allow this package, set 'AllowPackage_CliWrap=true'."
+		       Condition="'$(AllowPackage_CliWrap)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'CliWrap')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'CliWrap')) == 'true')" />
 	</Target>
 
 	<!-- NuGet Package -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -690,6 +690,65 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.Equal(0, data.ExitCode);
     }
 
+    [Theory]
+    [InlineData("YamlDotNet", "16.3.0", "Meziantou.Framework.Yaml", "AllowPackage_YamlDotNet")]
+    [InlineData("CliWrap", "3.7.0", "Meziantou.Framework.ProcessWrapper", "AllowPackage_CliWrap")]
+    public async Task BannedPackageReference_DirectReference_IsReported(string packageName, string packageVersion, string suggestedPackage, string allowProperty)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("TargetFramework", "net10.0")], nuGetPackages: [new NuGetReference(packageName, packageVersion)]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(1, data.ExitCode);
+        Assert.True(data.OutputContains($"Package '{packageName}' is not allowed.", StringComparison.Ordinal));
+        Assert.True(data.OutputContains($"Use '{suggestedPackage}' instead.", StringComparison.Ordinal));
+        Assert.True(data.OutputContains($"{allowProperty}=true", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("YamlDotNet", "16.3.0", "Meziantou.Framework.Yaml", "AllowPackage_YamlDotNet")]
+    [InlineData("CliWrap", "3.7.0", "Meziantou.Framework.ProcessWrapper", "AllowPackage_CliWrap")]
+    public async Task BannedPackageReference_TransitiveReference_IsReported(string packageName, string packageVersion, string suggestedPackage, string allowProperty)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddFile("Dependency/Dependency.csproj", $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="{{packageName}}" Version="{{packageVersion}}" />
+              </ItemGroup>
+            </Project>
+            """);
+        project.AddFile("Dependency/Class1.cs", "public sealed class Class1 {}\n");
+        project.AddCsprojFile(properties: [("TargetFramework", "net10.0")], additionalProjectElements:
+        [
+            new XElement("ItemGroup", new XElement("ProjectReference", new XAttribute("Include", "Dependency/Dependency.csproj"))),
+        ]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(1, data.ExitCode);
+        Assert.True(data.OutputContains($"Package '{packageName}' is not allowed.", StringComparison.Ordinal));
+        Assert.True(data.OutputContains($"Use '{suggestedPackage}' instead.", StringComparison.Ordinal));
+        Assert.True(data.OutputContains($"{allowProperty}=true", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("YamlDotNet", "16.3.0", "AllowPackage_YamlDotNet")]
+    [InlineData("CliWrap", "3.7.0", "AllowPackage_CliWrap")]
+    public async Task BannedPackageReference_CanBeAllowedPerPackage(string packageName, string packageVersion, string allowProperty)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("TargetFramework", "net10.0"), (allowProperty, "true")], nuGetPackages: [new NuGetReference(packageName, packageVersion)]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+    }
+
     [Fact]
     public async Task MSBuildWarningsAsError()
     {


### PR DESCRIPTION
This adds SDK-level package guardrails so projects fail fast when they use packages we want to avoid. The goal is to steer consumers toward the Meziantou alternatives with clear, actionable build errors.

## What changed
- Added `FailOnBannedPackageReferences` in `src/common/Common.targets`.
- Added default banned package entries:
  - `YamlDotNet` -> `Meziantou.Framework.Yaml`
  - `CliWrap` -> `Meziantou.Framework.ProcessWrapper`
- Detection now covers:
  - direct references via `PackageReference`
  - transitive references via `ReferencePath` `NuGetPackageId` metadata
- Added per-package opt-out properties:
  - `AllowPackage_YamlDotNet`
  - `AllowPackage_CliWrap`
- Added SDK tests for direct detection, transitive detection, and per-package opt-out behavior.
- Updated README documentation for the new rules and allow switches.

## Notes for reviewers
- The transitive check intentionally uses MSBuild item metadata from resolved references instead of reading `project.assets.json` directly.