### PR TITLE
Forbid Testcontainers NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Set these properties in your project file or a directory-level props file. Unles
 The SDK also blocks selected NuGet packages by default:
 - `YamlDotNet` (use `Meziantou.Framework.Yaml`)
 - `CliWrap` (use `Meziantou.Framework.ProcessWrapper`)
+- `Testcontainers` (use `Meziantou.Framework.TemporaryContainers`)
 
 | Property | Default | Description |
 | --- | --- | --- |
@@ -140,6 +141,7 @@ The SDK also blocks selected NuGet packages by default:
 | `BannedNewtonsoftJsonSymbols` | `true` | Includes banned Newtonsoft.Json APIs. |
 | `AllowPackage_YamlDotNet` | unset (`false`) | Allows `YamlDotNet` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.Yaml`. |
 | `AllowPackage_CliWrap` | unset (`false`) | Allows `CliWrap` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.ProcessWrapper`. |
+| `AllowPackage_Testcontainers` | unset (`false`) | Allows `Testcontainers` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.TemporaryContainers`. |
 | `Disable_SponsorLink` | `true` | Removes SponsorLink and Moq analyzers when not set to `false`. |
 
 ## Web SDK and containers

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -128,6 +128,8 @@
 		       Condition="'$(AllowPackage_YamlDotNet)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'YamlDotNet')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'YamlDotNet')) == 'true')" />
 		<Error Text="Package 'CliWrap' is not allowed. Use 'Meziantou.Framework.ProcessWrapper' instead. To allow this package, set 'AllowPackage_CliWrap=true'."
 		       Condition="'$(AllowPackage_CliWrap)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'CliWrap')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'CliWrap')) == 'true')" />
+		<Error Text="Package 'Testcontainers' is not allowed. Use 'Meziantou.Framework.TemporaryContainers' instead. To allow this package, set 'AllowPackage_Testcontainers=true'."
+		       Condition="'$(AllowPackage_Testcontainers)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'Testcontainers')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'Testcontainers')) == 'true')" />
 	</Target>
 
 	<!-- NuGet Package -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -693,6 +693,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     [Theory]
     [InlineData("YamlDotNet", "16.3.0", "Meziantou.Framework.Yaml", "AllowPackage_YamlDotNet")]
     [InlineData("CliWrap", "3.7.0", "Meziantou.Framework.ProcessWrapper", "AllowPackage_CliWrap")]
+    [InlineData("Testcontainers", "4.13.0", "Meziantou.Framework.TemporaryContainers", "AllowPackage_Testcontainers")]
     public async Task BannedPackageReference_DirectReference_IsReported(string packageName, string packageVersion, string suggestedPackage, string allowProperty)
     {
         await using var project = CreateProjectBuilder();
@@ -709,6 +710,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     [Theory]
     [InlineData("YamlDotNet", "16.3.0", "Meziantou.Framework.Yaml", "AllowPackage_YamlDotNet")]
     [InlineData("CliWrap", "3.7.0", "Meziantou.Framework.ProcessWrapper", "AllowPackage_CliWrap")]
+    [InlineData("Testcontainers", "4.13.0", "Meziantou.Framework.TemporaryContainers", "AllowPackage_Testcontainers")]
     public async Task BannedPackageReference_TransitiveReference_IsReported(string packageName, string packageVersion, string suggestedPackage, string allowProperty)
     {
         await using var project = CreateProjectBuilder();
@@ -739,6 +741,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     [Theory]
     [InlineData("YamlDotNet", "16.3.0", "AllowPackage_YamlDotNet")]
     [InlineData("CliWrap", "3.7.0", "AllowPackage_CliWrap")]
+    [InlineData("Testcontainers", "4.13.0", "AllowPackage_Testcontainers")]
     public async Task BannedPackageReference_CanBeAllowedPerPackage(string packageName, string packageVersion, string allowProperty)
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
This change extends the SDK's banned package checks to discourage `Testcontainers` usage and guide projects toward `Meziantou.Framework.TemporaryContainers` for temporary container scenarios.

## What changed
- Added a new banned package rule in `FailOnBannedPackageReferences` for `Testcontainers`.
- Added a clear remediation message suggesting `Meziantou.Framework.TemporaryContainers`.
- Added `AllowPackage_Testcontainers=true` as the per-package opt-out, consistent with existing package bans.
- Extended existing banned-package tests (direct, transitive, and opt-out scenarios) with `Testcontainers`.
- Updated README documentation to list the new banned package and opt-out property.

## Notes
- `dotnet build` succeeds for the repository.
- The existing `BannedPackageReference` test subset currently fails in this environment due a pre-existing SDK packaging/import path issue unrelated to this change (same failure pattern as existing `YamlDotNet`/`CliWrap` cases).