### PR TITLE
Handle missing test binlog

### DIFF
--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -296,26 +296,6 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             environmentChanges["DOTNET_ROOT_ARM64"] = dotnetRoot;
         }
 
-        var sdkRoot = Path.Combine(dotnetRoot, "sdk");
-        if (Directory.Exists(sdkRoot))
-        {
-            var preferredSdkPath = Path.Combine(sdkRoot, Path.GetFileName(dotnetRoot));
-            string? sdkPath = Directory.Exists(preferredSdkPath)
-                ? preferredSdkPath
-                : Directory.GetDirectories(sdkRoot)
-                    .OrderByDescending(path => Path.GetFileName(path), StringComparer.OrdinalIgnoreCase)
-                    .FirstOrDefault();
-
-            if (sdkPath is not null)
-            {
-                var msbuildSdksPath = Path.Combine(sdkPath, "Sdks");
-                if (Directory.Exists(msbuildSdksPath))
-                {
-                    environmentChanges["MSBuildSDKsPath"] = msbuildSdksPath;
-                }
-            }
-        }
-
         if (environmentVariables != null)
         {
             foreach (var env in environmentVariables)

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -296,6 +296,26 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             environmentChanges["DOTNET_ROOT_ARM64"] = dotnetRoot;
         }
 
+        var sdkRoot = Path.Combine(dotnetRoot, "sdk");
+        if (Directory.Exists(sdkRoot))
+        {
+            var preferredSdkPath = Path.Combine(sdkRoot, Path.GetFileName(dotnetRoot));
+            string? sdkPath = Directory.Exists(preferredSdkPath)
+                ? preferredSdkPath
+                : Directory.GetDirectories(sdkRoot)
+                    .OrderByDescending(path => Path.GetFileName(path), StringComparer.OrdinalIgnoreCase)
+                    .FirstOrDefault();
+
+            if (sdkPath is not null)
+            {
+                var msbuildSdksPath = Path.Combine(sdkPath, "Sdks");
+                if (Directory.Exists(msbuildSdksPath))
+                {
+                    environmentChanges["MSBuildSDKsPath"] = msbuildSdksPath;
+                }
+            }
+        }
+
         if (environmentVariables != null)
         {
             foreach (var env in environmentVariables)

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -411,8 +411,16 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             _testOutputHelper.WriteLine("Sarif file not found: " + sarifPath);
         }
 
-        var binlogContent = File.ReadAllBytes(binlogPath);
-        TestContext.Current.AddAttachment($"msbuild{_buildCount}.binlog", binlogContent);
+        byte[]? binlogContent = null;
+        if (File.Exists(binlogPath))
+        {
+            binlogContent = File.ReadAllBytes(binlogPath);
+            TestContext.Current.AddAttachment($"msbuild{_buildCount}.binlog", binlogContent);
+        }
+        else
+        {
+            _testOutputHelper.WriteLine("Binlog file not found: " + binlogPath);
+        }
 
         string? vstestDiagContent = null;
         if (File.Exists(vstestdiagPath))


### PR DESCRIPTION
The main CI failures were being caused by the test harness, not by the SDK behavior under test. Some failing `dotnet test` runs do not produce `msbuild.binlog`, and the test helper was unconditionally reading that file, which raised `FileNotFoundException` and hid the real failure details.

This change makes the test infrastructure tolerate missing binlogs by only attaching `msbuild.binlog` when it exists and logging when it does not. That keeps the original test result intact so CI reports the actual failure instead of crashing inside the helper.

The remaining `VSTests_OnUnknownContextShouldNotAddCustomLogger` failure appears to be a separate `dotnet test` host/runtime issue rather than the missing-binlog crash.