### PR TITLE
Fix generated NuGet package file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ paket-files/
 __pycache__/
 *.pyc
 *.binlog
+.DS_Store

--- a/src/Meziantou.NET.Sdk.BlazorWebAssembly.nuspec
+++ b/src/Meziantou.NET.Sdk.BlazorWebAssembly.nuspec
@@ -13,11 +13,28 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.BlazorWebAssembly/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.BlazorWebAssembly/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
-    <file src="icon.png" target="" />
-    <file src="icon.svg" target="" />
-    <file src="../LICENSE.txt" target="" />
-    <file src="../README.md" target="" />
+    <file src="common/Common.props" target="common/Common.props" />
+    <file src="common/Common.targets" target="common/Common.targets" />
+    <file src="common/ContinuousIntegrationBuild.props" target="common/ContinuousIntegrationBuild.props" />
+    <file src="common/Npm.targets" target="common/Npm.targets" />
+    <file src="common/Tests.targets" target="common/Tests.targets" />
+    <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
+    <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
+    <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />
+    <file src="configuration/Compiler.editorconfig" target="configuration/Compiler.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" target="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" target="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.Web.editorconfig" target="configuration/Meziantou.NET.Sdk.Web.editorconfig" />
+    <file src="configuration/NamingConvention.editorconfig" target="configuration/NamingConvention.editorconfig" />
+    <file src="configuration/default.runsettings" target="configuration/default.runsettings" />
+    <file src="icon.png" target="icon.png" />
+    <file src="icon.svg" target="icon.svg" />
+    <file src="../LICENSE.txt" target="LICENSE.txt" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/src/Meziantou.NET.Sdk.Razor.nuspec
+++ b/src/Meziantou.NET.Sdk.Razor.nuspec
@@ -13,11 +13,28 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.Razor/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.Razor/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
-    <file src="icon.png" target="" />
-    <file src="icon.svg" target="" />
-    <file src="../LICENSE.txt" target="" />
-    <file src="../README.md" target="" />
+    <file src="common/Common.props" target="common/Common.props" />
+    <file src="common/Common.targets" target="common/Common.targets" />
+    <file src="common/ContinuousIntegrationBuild.props" target="common/ContinuousIntegrationBuild.props" />
+    <file src="common/Npm.targets" target="common/Npm.targets" />
+    <file src="common/Tests.targets" target="common/Tests.targets" />
+    <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
+    <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
+    <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />
+    <file src="configuration/Compiler.editorconfig" target="configuration/Compiler.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" target="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" target="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.Web.editorconfig" target="configuration/Meziantou.NET.Sdk.Web.editorconfig" />
+    <file src="configuration/NamingConvention.editorconfig" target="configuration/NamingConvention.editorconfig" />
+    <file src="configuration/default.runsettings" target="configuration/default.runsettings" />
+    <file src="icon.png" target="icon.png" />
+    <file src="icon.svg" target="icon.svg" />
+    <file src="../LICENSE.txt" target="LICENSE.txt" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/src/Meziantou.NET.Sdk.Test.nuspec
+++ b/src/Meziantou.NET.Sdk.Test.nuspec
@@ -13,11 +13,28 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.Test/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.Test/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
-    <file src="icon.png" target="" />
-    <file src="icon.svg" target="" />
-    <file src="../LICENSE.txt" target="" />
-    <file src="../README.md" target="" />
+    <file src="common/Common.props" target="common/Common.props" />
+    <file src="common/Common.targets" target="common/Common.targets" />
+    <file src="common/ContinuousIntegrationBuild.props" target="common/ContinuousIntegrationBuild.props" />
+    <file src="common/Npm.targets" target="common/Npm.targets" />
+    <file src="common/Tests.targets" target="common/Tests.targets" />
+    <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
+    <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
+    <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />
+    <file src="configuration/Compiler.editorconfig" target="configuration/Compiler.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" target="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" target="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.Web.editorconfig" target="configuration/Meziantou.NET.Sdk.Web.editorconfig" />
+    <file src="configuration/NamingConvention.editorconfig" target="configuration/NamingConvention.editorconfig" />
+    <file src="configuration/default.runsettings" target="configuration/default.runsettings" />
+    <file src="icon.png" target="icon.png" />
+    <file src="icon.svg" target="icon.svg" />
+    <file src="../LICENSE.txt" target="LICENSE.txt" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/src/Meziantou.NET.Sdk.Web.nuspec
+++ b/src/Meziantou.NET.Sdk.Web.nuspec
@@ -13,11 +13,28 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.Web/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.Web/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
-    <file src="icon.png" target="" />
-    <file src="icon.svg" target="" />
-    <file src="../LICENSE.txt" target="" />
-    <file src="../README.md" target="" />
+    <file src="common/Common.props" target="common/Common.props" />
+    <file src="common/Common.targets" target="common/Common.targets" />
+    <file src="common/ContinuousIntegrationBuild.props" target="common/ContinuousIntegrationBuild.props" />
+    <file src="common/Npm.targets" target="common/Npm.targets" />
+    <file src="common/Tests.targets" target="common/Tests.targets" />
+    <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
+    <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
+    <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />
+    <file src="configuration/Compiler.editorconfig" target="configuration/Compiler.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" target="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" target="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.Web.editorconfig" target="configuration/Meziantou.NET.Sdk.Web.editorconfig" />
+    <file src="configuration/NamingConvention.editorconfig" target="configuration/NamingConvention.editorconfig" />
+    <file src="configuration/default.runsettings" target="configuration/default.runsettings" />
+    <file src="icon.png" target="icon.png" />
+    <file src="icon.svg" target="icon.svg" />
+    <file src="../LICENSE.txt" target="LICENSE.txt" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/src/Meziantou.NET.Sdk.WindowsDesktop.nuspec
+++ b/src/Meziantou.NET.Sdk.WindowsDesktop.nuspec
@@ -13,11 +13,28 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk.WindowsDesktop/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk.WindowsDesktop/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
-    <file src="icon.png" target="" />
-    <file src="icon.svg" target="" />
-    <file src="../LICENSE.txt" target="" />
-    <file src="../README.md" target="" />
+    <file src="common/Common.props" target="common/Common.props" />
+    <file src="common/Common.targets" target="common/Common.targets" />
+    <file src="common/ContinuousIntegrationBuild.props" target="common/ContinuousIntegrationBuild.props" />
+    <file src="common/Npm.targets" target="common/Npm.targets" />
+    <file src="common/Tests.targets" target="common/Tests.targets" />
+    <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
+    <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
+    <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />
+    <file src="configuration/Compiler.editorconfig" target="configuration/Compiler.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" target="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" target="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.Web.editorconfig" target="configuration/Meziantou.NET.Sdk.Web.editorconfig" />
+    <file src="configuration/NamingConvention.editorconfig" target="configuration/NamingConvention.editorconfig" />
+    <file src="configuration/default.runsettings" target="configuration/default.runsettings" />
+    <file src="icon.png" target="icon.png" />
+    <file src="icon.svg" target="icon.svg" />
+    <file src="../LICENSE.txt" target="LICENSE.txt" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/src/Meziantou.NET.Sdk.nuspec
+++ b/src/Meziantou.NET.Sdk.nuspec
@@ -13,11 +13,28 @@
   <files>
     <file src="Sdk/Meziantou.NET.Sdk/Sdk.props" target="Sdk/Sdk.props" />
     <file src="Sdk/Meziantou.NET.Sdk/Sdk.targets" target="Sdk/Sdk.targets" />
-    <file src="common/**/*" target="" />
-    <file src="configuration/**/*" target="" />
-    <file src="icon.png" target="" />
-    <file src="icon.svg" target="" />
-    <file src="../LICENSE.txt" target="" />
-    <file src="../README.md" target="" />
+    <file src="common/Common.props" target="common/Common.props" />
+    <file src="common/Common.targets" target="common/Common.targets" />
+    <file src="common/ContinuousIntegrationBuild.props" target="common/ContinuousIntegrationBuild.props" />
+    <file src="common/Npm.targets" target="common/Npm.targets" />
+    <file src="common/Tests.targets" target="common/Tests.targets" />
+    <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
+    <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
+    <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />
+    <file src="configuration/Compiler.editorconfig" target="configuration/Compiler.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" target="configuration/Meziantou.NET.Sdk.NetStandard2_0.MultiTarget.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" target="configuration/Meziantou.NET.Sdk.SingleFileApp.editorconfig" />
+    <file src="configuration/Meziantou.NET.Sdk.Web.editorconfig" target="configuration/Meziantou.NET.Sdk.Web.editorconfig" />
+    <file src="configuration/NamingConvention.editorconfig" target="configuration/NamingConvention.editorconfig" />
+    <file src="configuration/default.runsettings" target="configuration/default.runsettings" />
+    <file src="icon.png" target="icon.png" />
+    <file src="icon.svg" target="icon.svg" />
+    <file src="../LICENSE.txt" target="LICENSE.txt" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/tools/ConfigFilesGenerator/Program.cs
+++ b/tools/ConfigFilesGenerator/Program.cs
@@ -196,7 +196,7 @@ async Task GenerateBanSymbolsForNewtonsoftJson()
     var bannedSymbols = new HashSet<string>(StringComparer.Ordinal);
 
     var package = await DownloadNuGetPackage("Newtonsoft.Json", version: null, NullLogger.Instance, CancellationToken.None);
-    var libItems = await package.PackageReader.GetLibItemsAsync(CancellationToken.None);
+    var libItems = await package.PackageReader!.GetLibItemsAsync(CancellationToken.None);
 
     var compatibleFrameworks = libItems.Where(item => DefaultCompatibilityProvider.Instance.IsCompatible(NuGetFramework.Parse("net10.0"), item.TargetFramework));
     var items = compatibleFrameworks.SelectMany(item => item.Items).ToArray();
@@ -290,7 +290,7 @@ async Task<(string Id, NuGetVersion Version)[]> GetAllReferencedNuGetPackages()
         var version = package.Version is null ? null : NuGetVersion.Parse(package.Version);
         if (version is null)
         {
-            var metadata = await resource.GetMetadataAsync(package.Id, includePrerelease: true, includeUnlisted: false, cache, NullLogger.Instance, CancellationToken.None);
+            var metadata = await resource!.GetMetadataAsync(package.Id, includePrerelease: true, includeUnlisted: false, cache, NullLogger.Instance, CancellationToken.None);
             version = metadata.MaxBy(metadata => metadata.Identity.Version)!.Identity.Version;
         }
 
@@ -321,7 +321,7 @@ if(package.Id is "Meziantou.Analyzer")
         foreach (var repository in repositories)
         {
             var dependencyInfoResource = await repository.GetResourceAsync<DependencyInfoResource>();
-            var dependencyInfo = await dependencyInfoResource.ResolvePackage(package, framework, cache, logger, cancellationToken);
+            var dependencyInfo = await dependencyInfoResource!.ResolvePackage(package, framework, cache, logger, cancellationToken);
 
             if (dependencyInfo == null)
             {
@@ -376,7 +376,7 @@ static async Task<Assembly[]> GetAnalyzerReferences(string packageId, NuGetVersi
 
     var package = await DownloadNuGetPackage(packageId, version, logger, cancellationToken);
     var result = new List<Assembly>();
-    var files = package.PackageReader.GetFiles("analyzers");
+    var files = package.PackageReader!.GetFiles("analyzers");
     var filesGroupedByFolder = files.GroupBy(Path.GetDirectoryName).ToArray();
     foreach (var group in filesGroupedByFolder)
     {
@@ -639,7 +639,7 @@ static async Task<DownloadResourceResult> DownloadNuGetPackage(string packageId,
     if (version is null)
     {
         var metadataResource = await repository.GetResourceAsync<PackageMetadataResource>();
-        var metadata = await metadataResource.GetMetadataAsync(packageId, includePrerelease: true, includeUnlisted: false, cache, NullLogger.Instance, CancellationToken.None);
+        var metadata = await metadataResource!.GetMetadataAsync(packageId, includePrerelease: true, includeUnlisted: false, cache, NullLogger.Instance, CancellationToken.None);
         version = metadata.MaxBy(metadata => metadata.Identity.Version)!.Identity.Version;
     }
 
@@ -648,7 +648,7 @@ static async Task<DownloadResourceResult> DownloadNuGetPackage(string packageId,
     {
         // Download the package
         using var packageStream = new MemoryStream();
-        await resource.CopyNupkgToStreamAsync(
+        await resource!.CopyNupkgToStreamAsync(
             packageId,
             version,
             packageStream,

--- a/tools/SdkGenerator/Program.cs
+++ b/tools/SdkGenerator/Program.cs
@@ -63,6 +63,8 @@ foreach (var (sdkName, baseSdkName) in sdks)
         </Project>
         """);
 
+    var nuspecFiles = GetNuspecFiles(rootFolder / "src", sdkName);
+
     File.WriteAllText(nuspecPath, $$"""
         <?xml version="1.0"?>
         <package>
@@ -77,14 +79,7 @@ foreach (var (sdkName, baseSdkName) in sdks)
             <repository type="git" url="$RepositoryUrl$" commit="$RepositoryCommit$" branch="$RepositoryBranch$" />
           </metadata>
           <files>
-            <file src="Sdk/{{sdkName}}/Sdk.props" target="Sdk/Sdk.props" />
-            <file src="Sdk/{{sdkName}}/Sdk.targets" target="Sdk/Sdk.targets" />
-            <file src="common/**/*" target="" />
-            <file src="configuration/**/*" target="" />
-            <file src="icon.png" target="" />
-            <file src="icon.svg" target="" />
-            <file src="../LICENSE.txt" target="" />
-            <file src="../README.md" target="" />
+        {{nuspecFiles}}
           </files>
         </package>
         """);
@@ -97,7 +92,7 @@ static FullPath GetRootFolderPath()
     var path = FullPath.CurrentDirectory();
     while (!path.IsEmpty)
     {
-        if (Directory.Exists(path / ".git"))
+        if (Directory.Exists(path / ".git") || File.Exists(path / ".git"))
             return path;
 
         path = path.Parent;
@@ -107,4 +102,33 @@ static FullPath GetRootFolderPath()
         throw new InvalidOperationException("Cannot find the root folder");
 
     return path;
+}
+
+static string GetNuspecFiles(FullPath srcFolderPath, string sdkName)
+{
+    var files = new List<(string Source, string Target)>
+    {
+        ($"Sdk/{sdkName}/Sdk.props", "Sdk/Sdk.props"),
+        ($"Sdk/{sdkName}/Sdk.targets", "Sdk/Sdk.targets"),
+    };
+
+    AddDirectoryFiles(files, srcFolderPath, "common");
+    AddDirectoryFiles(files, srcFolderPath, "configuration");
+
+    files.Add(("icon.png", "icon.png"));
+    files.Add(("icon.svg", "icon.svg"));
+    files.Add(("../LICENSE.txt", "LICENSE.txt"));
+    files.Add(("../README.md", "README.md"));
+
+    return string.Join(Environment.NewLine, files.Select(file => $"    <file src=\"{file.Source}\" target=\"{file.Target}\" />"));
+}
+
+static void AddDirectoryFiles(List<(string Source, string Target)> files, FullPath srcFolderPath, string directoryName)
+{
+    var directoryPath = srcFolderPath / directoryName;
+    foreach (var filePath in Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+    {
+        var relativePath = Path.GetRelativePath(srcFolderPath, filePath).Replace('\\', '/');
+        files.Add((relativePath, relativePath));
+    }
 }


### PR DESCRIPTION
## Summary

- Generate explicit nuspec entries for shared files and configuration files.
- Preserve directory structure and package metadata paths for all SDK packages.
- Support repository root detection when `.git` is a file.

## Testing

- Not run (not requested)