### PR TITLE
Update .NET 11 SDK test version to preview 7

### DIFF
--- a/tests/Meziantou.Sdk.Tests/Helpers/DotNetSdkHelpers.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/DotNetSdkHelpers.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Sdk.Tests.Helpers;
 public static class DotNetSdkHelpers
 {
     private const string Net10SdkVersion = "10.0.302";
-    private const string Net11SdkVersion = "11.0.100-preview.6.26359.118";
+    private const string Net11SdkVersion = "11.0.100-preview.7.26381.103";
 
     private static readonly ConcurrentDictionary<NetSdkVersion, FullPath> Values = new();
     private static readonly KeyedAsyncLock<NetSdkVersion> KeyedAsyncLock = new();

--- a/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/ProjectBuilder.cs
@@ -273,6 +273,7 @@ internal sealed class ProjectBuilder : IAsyncDisposable
             ["DOTNET_HOST_PATH"] = dotnetPath,
             ["DOTNET_ROLL_FORWARD"] = "LatestMajor",
             ["DOTNET_ROLL_FORWARD_TO_PRERELEASE"] = "1",
+            ["MSBuildExtensionsPath"] = null,
             ["NUGET_HTTP_CACHE_PATH"] = _fixture.PackageDirectory / "http-cache",
             ["NUGET_PACKAGES"] = _fixture.PackageDirectory,
             ["NUGET_SCRATCH"] = _fixture.PackageDirectory / "nuget-scratch",
@@ -308,6 +309,8 @@ internal sealed class ProjectBuilder : IAsyncDisposable
 
             if (sdkPath is not null)
             {
+                environmentChanges["MSBuildExtensionsPath"] = sdkPath + Path.DirectorySeparatorChar;
+
                 var msbuildSdksPath = Path.Combine(sdkPath, "Sdks");
                 if (Directory.Exists(msbuildSdksPath))
                 {


### PR DESCRIPTION
## Summary

- Update test helpers to use the .NET 11 preview 7 SDK.
- Configure `MSBuildExtensionsPath` so SDK-specific MSBuild extensions resolve correctly.

## Testing

- Not run (not requested).