### PR TITLE
Upgrade tests to xunit.v3 4.0.0 (native parallelization + Microsoft Testing Platform)

### DIFF
--- a/.github/run-sharded-tests.ps1
+++ b/.github/run-sharded-tests.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+    Runs a deterministic shard of a Microsoft Testing Platform (xUnit.net v3) test
+    project using 'dotnet test' in MTP mode.
+
+.DESCRIPTION
+    Discovers the tests at method granularity (theories are not pre-enumerated so
+    that the shard assignment stays stable), splits them across the requested number
+    of shards, and runs only the tests that belong to the current shard using exact
+    '--filter-method' matches. A TRX report is written to the results directory.
+#>
+
+param(
+    [Parameter(Mandatory = $true)][int]$ShardIndex,
+    [Parameter(Mandatory = $true)][int]$TotalShards,
+    [Parameter(Mandatory = $true)][string]$Project,
+    [string]$ResultsDirectory = "test_results"
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($ShardIndex -lt 1 -or $ShardIndex -gt $TotalShards) {
+    throw "ShardIndex must be between 1 and TotalShards ($TotalShards)."
+}
+
+dotnet build $Project
+if ($LASTEXITCODE -ne 0) {
+    throw "Build failed with exit code $LASTEXITCODE."
+}
+
+# Discover tests at method granularity (theories are not pre-enumerated).
+$listOutput = dotnet test $Project --no-build --list-tests --pre-enumerate-theories off | Out-String
+if ($LASTEXITCODE -ne 0) {
+    Write-Host $listOutput
+    throw "Test discovery failed with exit code $LASTEXITCODE."
+}
+
+# Test names are fully-qualified method names: no whitespace and at least one dot.
+# This excludes every other line printed by the platform (banners, the
+# "Discovered N tests." summary, build output, ...).
+$tests = foreach ($line in ($listOutput -split "`r?`n")) {
+    $trimmed = $line.Trim()
+    if ($trimmed -and -not ($trimmed -match '\s') -and $trimmed.Contains('.')) {
+        $trimmed
+    }
+}
+
+$tests = $tests | Sort-Object -CaseSensitive -Unique
+if ($tests.Count -eq 0) {
+    throw "No tests were discovered."
+}
+
+$selected = for ($i = 0; $i -lt $tests.Count; $i++) {
+    if (($i % $TotalShards) -eq ($ShardIndex - 1)) { $tests[$i] }
+}
+
+Write-Host "Shard $ShardIndex/$TotalShards selected $($selected.Count) of $($tests.Count) tests."
+if ($selected.Count -eq 0) {
+    exit 0
+}
+
+$filterArgs = foreach ($test in $selected) { "--filter-method"; $test }
+
+dotnet test $Project --no-build --pre-enumerate-theories off `
+    --report-xunit-trx --results-directory $ResultsDirectory @filterArgs
+exit $LASTEXITCODE

--- a/.github/sharded-tests.runsettings
+++ b/.github/sharded-tests.runsettings
@@ -1,5 +1,0 @@
-<RunSettings>
-  <xUnit>
-    <PreEnumerateTheories>false</PreEnumerateTheories>
-  </xUnit>
-</RunSettings>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - run: Get-ChildItem "${{ env.NUGET_DIRECTORY }}/*" -Recurse
       - run: dotnet --info
-      - run: dotnet tool install --global Meziantou.ShardedTest
-      - run: sharded-test --shard-index ${{ matrix.shard-index }} --total-shards 4 tests/Meziantou.Sdk.Tests --logger "trx" --results-directory test_results --settings .github/sharded-tests.runsettings
+      - name: Run tests (shard ${{ matrix.shard-index }}/4)
+        run: ./.github/run-sharded-tests.ps1 -ShardIndex ${{ matrix.shard-index }} -TotalShards 4 -Project tests/Meziantou.Sdk.Tests -ResultsDirectory test_results
         env:
             NUGET_DIRECTORY: ${{ env.NUGET_DIRECTORY }}
             PACKAGE_VERSION: ${{ needs.compute_version.outputs.package_version }}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
   "sdk": {
     "version": "10.0.400"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs
@@ -1,7 +1,10 @@
 using Meziantou.Framework;
 using Meziantou.Sdk.Tests.Helpers;
+using Xunit.Sdk;
+using Xunit.v3;
 
 [assembly: AssemblyFixture(typeof(PackageFixture))]
+[assembly: Parallelization(Mode = ParallelMode.All)]
 
 namespace Meziantou.Sdk.Tests.Helpers;
 

--- a/tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj
+++ b/tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj
@@ -6,6 +6,8 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,13 +15,12 @@
     <PackageReference Include="Meziantou.Framework.ProcessWrapper" Version="2.0.1" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="3.0.1" />
     <PackageReference Include="Meziantou.Framework.Threading" Version="3.0.0" />
-    <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.3.244" />
     <PackageReference Include="NuGet.Packaging" Version="7.9.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -27,13 +27,13 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     ];
     private static readonly NuGetReference[] XUnit3References =
     [
-        new NuGetReference("xunit.v3", "3.2.0"),
-        new NuGetReference("xunit.runner.visualstudio", "3.1.5"),
+        new NuGetReference("xunit.v3", "4.0.0"),
+        new NuGetReference("xunit.runner.visualstudio", "4.0.0"),
     ];
     private static readonly NuGetReference[] XUnit3MTP2References =
     [
-        new NuGetReference("xunit.v3.mtp-v2", "3.2.0"),
-        new NuGetReference("xunit.runner.visualstudio", "3.1.5"),
+        new NuGetReference("xunit.v3.mtp-v2", "4.0.0"),
+        new NuGetReference("xunit.runner.visualstudio", "4.0.0"),
     ];
     private static readonly NuGetReference[] TUnitReferences =
     [


### PR DESCRIPTION
Updates the test suite to xunit.v3 **4.0.0** and moves CI to **Microsoft Testing Platform**.

## Test project changes
**`tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj`**
- `xunit.v3` 3.2.2 → **4.0.0**, `xunit.runner.visualstudio` 3.1.5 → **4.0.0**
- Removed `Meziantou.Xunit.v3.ParallelTestFramework` — its in-class parallelism is now built into xunit 4.0
- Added `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>`
- Kept `Microsoft.NET.Test.Sdk` for backward compatibility, as the xunit docs recommend

**`tests/Meziantou.Sdk.Tests/Helpers/PackageFixture.cs`** — enabled native parallelization:
```csharp
[assembly: Parallelization(Mode = ParallelMode.All)]
```
`ParallelMode.All` (new in 4.0) runs tests in parallel even within a class — matching what the removed framework did.

**`tests/Meziantou.Sdk.Tests/SdkTests.cs`** — the reference sets used to generate xunit test projects (`xunit.v3`, `xunit.v3.mtp-v2`, `xunit.runner.visualstudio`) bumped to **4.0.0**. The xunit v2 set is left as-is since it deliberately tests v2 compatibility.

## CI changes
On the .NET 10 SDK, an MTP v2 project can no longer run through the legacy VSTest path of `dotnet test` (even the `TestingPlatformDotnetTestSupport` bridge fails). Two consequences:

- **`global.json`** — added the `test.runner` opt-in so `dotnet test` uses MTP mode (only the `test` section is added; the pinned SDK version is untouched):
  ```json
  "test": { "runner": "Microsoft.Testing.Platform" }
  ```
- **`Meziantou.ShardedTest` replaced.** That tool parses VSTest's `--list-tests` output format, which MTP doesn't emit, so it selected 0 tests. Replaced with a self-contained **`.github/run-sharded-tests.ps1`** that discovers tests (method granularity, `--pre-enumerate-theories off`), partitions them deterministically across the 4 shards, and runs each shard with exact `--filter-method` matches (correctly handles theory data rows and method-name prefix collisions like `NpmRestore` vs `NpmRestore_Disabled…`). TRX comes from xunit's `--report-xunit-trx`.
- Deleted **`.github/sharded-tests.runsettings`** (VSTest-only; its `PreEnumerateTheories=false` is now `--pre-enumerate-theories off`).

## Verification
- `dotnet build` succeeds; the new `Parallelization`/`ParallelMode` API resolves; packages restore at 4.0.0.
- The built assembly runs as an MTP app (`--help` shows MTP options).
- `dotnet test` MTP mode confirmed working: `--list-tests` and repeated exact `--filter-method` behave correctly.
- The CI shard script was run end-to-end locally (build → discover 188 → select shard → run → TRX): shards pass and the 4-way partition is complete and disjoint (47 tests each, 188 total, no overlap).
- Ran representative MTP + xunit-v2 generation tests under the MTP runner: all pass.

## Notes for reviewers
- Adding the `test` section to `global.json` is the only supported way to run MTP tests through `dotnet test` on the .NET 10 SDK; it doesn't change the SDK version.
- The full 188-test suite wasn't run locally end-to-end (each test builds/packs real projects — expensive); CI covers it. The sharding harness itself was validated as above.
- Alternative considered: instead of the inline shard script, `Meziantou.ShardedTest` could be updated to parse MTP `--list-tests` output and re-published; happy to go that route if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)