### PR TITLE
Add xunit.v3 and MTP by default in Meziantou.NET.Sdk.Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ MSBuild SDK that helps standardize build and quality settings across repositorie
 - A static analysis baseline with Roslyn analyzers
 - Set `ContinuousIntegrationBuild` based on the context
 - dotnet test features
+  - xUnit.net v3 and Microsoft Testing Platform (MTP) by default
   - Dump on crash or hang
   - Loggers when running on GitHub
+  - Annotations and job summary when running on GitHub Actions
   - Disable Roslyn analyzers to speed up build
 - Relevant NuGet packages based on the project type
 
@@ -177,13 +179,51 @@ The SDK also blocks selected NuGet packages by default:
 
 ## Testing
 
+A project using `Meziantou.NET.Sdk.Test` needs no `PackageReference` to run tests:
+
+````xml
+<Project Sdk="Meziantou.NET.Sdk.Test">
+</Project>
+````
+
+````csharp
+public class Tests
+{
+    [Fact]
+    public void Test1() { }
+}
+````
+
+It gets xUnit.net v3 on Microsoft Testing Platform, a TRX report, crash and hang dumps, code coverage
+on CI, and GitHub Actions annotations and job summary when running on GitHub Actions. Add the
+following to `global.json` so `dotnet test` runs in MTP mode:
+
+````json
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}
+````
+
+`dotnet test` only reports failures by default. Use `dotnet test --output Detailed` to also list the
+tests that passed — the option belongs to `dotnet test` itself, so it cannot be set from the project
+file.
+
+To use another test framework, reference it: the default framework is not added when the project
+already references `xunit`, `xunit.v3*`, `TUnit`, `MSTest`, or `NUnit`. Set
+`EnableDefaultTestFramework` to `false` for full control, which is also required for a test project
+that must stay a library (VSTest).
+
 | Property | Default | Description |
 | --- | --- | --- |
+| `EnableDefaultTestFramework` | `true` | Adds `xunit.v3.mtp-v2` when no test framework is referenced, sets `OutputType` to `Exe` (required by xUnit.net v3) and `UseMicrosoftTestingPlatformRunner` to `true`. |
+| `EnableGitHubActionsReport` | `true` | Adds `Microsoft.Testing.Extensions.GitHubActionsReport` and `--report-gh`. The extension is inert unless the build runs on GitHub Actions. |
 | `EnableCodeCoverage` | `true` on CI | Enables code coverage collection on CI. |
 | `OptimizeVsTestRun` | `true` | Disables analyzers during `dotnet test` unless set to `false`. |
-| `UseMicrosoftTestingPlatform` | Auto | Uses MTP when set to `true` or when `xunit.v3.mtp-v2` or `TUnit` is referenced. |
+| `UseMicrosoftTestingPlatform` | Auto | Uses MTP when set to `true` or when `xunit.v3`, `xunit.v3.mtp-v2`, `xunit.v3.core.mtp-v2`, or `TUnit` is referenced. `Microsoft.NET.Test.Sdk` is added only when MTP is not used. |
 | `EnableDefaultTestSettings` | `true` | Adds default crash/hang dumps and loggers. |
-| `TestingPlatformCommandLineArguments` | Appended | Adds MTP arguments such as `--report-trx` and `--coverage` when enabled. |
+| `TestingPlatformCommandLineArguments` | Appended | Adds MTP arguments such as `--report-trx`, `--report-gh` and `--coverage` when enabled. |
 | `VSTestBlame` | `true` | Enables VSTest blame. |
 | `VSTestBlameCrash` | `true` | Enables crash dumps. |
 | `VSTestBlameCrashDumpType` | `mini` | Sets crash dump type. |

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -2,7 +2,7 @@
   <!-- When running dotnet test, disable analyzers to compile faster and get feedback earlier -->
   <!-- This assume that most CI uses an actual dotnet build/publish/pack in parallel of dotnet test -->
   <PropertyGroup>
-    <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
+    <IsPackable>false</IsPackable>
     <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">true</EnableCodeCoverage>
     <EnableDefaultTestFramework Condition="'$(EnableDefaultTestFramework)' == ''">true</EnableDefaultTestFramework>
     <EnableGitHubActionsReport Condition="'$(EnableGitHubActionsReport)' == ''">true</EnableGitHubActionsReport>

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -2,8 +2,18 @@
   <!-- When running dotnet test, disable analyzers to compile faster and get feedback earlier -->
   <!-- This assume that most CI uses an actual dotnet build/publish/pack in parallel of dotnet test -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">true</EnableCodeCoverage>
+    <EnableDefaultTestFramework Condition="'$(EnableDefaultTestFramework)' == ''">true</EnableDefaultTestFramework>
+    <EnableGitHubActionsReport Condition="'$(EnableGitHubActionsReport)' == ''">true</EnableGitHubActionsReport>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(EnableDefaultTestFramework)' == 'true'">
+    <!-- xUnit.net v3 test projects must be executables. 'Library' is the value set by Microsoft.NET.Sdk.props when the project doesn't set one -->
+    <OutputType Condition="'$(OutputType)' == 'Library'">Exe</OutputType>
+
+    <!-- Use the Microsoft Testing Platform command line instead of the xUnit.net console runner -->
+    <UseMicrosoftTestingPlatformRunner Condition="'$(UseMicrosoftTestingPlatformRunner)' == ''">true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <Target Name="DisableAnalyzerWhenRunningTests" BeforeTargets="VSTest;_MTPBuild" Condition="'$(OptimizeVsTestRun)' != 'false'">
@@ -12,10 +22,30 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Add the default test framework when the project doesn't reference one -->
+  <!-- This item group must be evaluated before the ones detecting the test platform to use -->
+  <ItemGroup Condition="'$(EnableDefaultTestFramework)' == 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.mtp-v1')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.mtp-v2')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.mtp-off')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-v2')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-off')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'TUnit')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'TUnit.Core')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'MSTest')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'MSTest.TestFramework')) != 'true' AND
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'NUnit')) != 'true'">
+    <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <!-- MTP -->
   <ItemGroup Condition="'$(UseMicrosoftTestingPlatform)' == 'true' OR ('$(UseMicrosoftTestingPlatform)' == '' AND (
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3')) == 'true' OR
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.mtp-v2')) == 'true' OR
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-v2')) == 'true' OR
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'TUnit')) == 'true'
                         ))">
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="2.3.3" IsImplicitlyDefined="true" />
@@ -24,10 +54,12 @@
     <PackageReference Include="Microsoft.Testing.Extensions.HotReload" Version="2.3.3" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="2.3.3" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="1.0.0-alpha.26377.5" IsImplicitlyDefined="true" Condition="'$(EnableGitHubActionsReport)' != 'false'" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(EnableDefaultTestSettings)' != 'false'">
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-trx</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments Condition="'$(EnableGitHubActionsReport)' != 'false'">$(TestingPlatformCommandLineArguments) --report-gh</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition="'$(EnableCodeCoverage)' == 'true'">$(TestingPlatformCommandLineArguments) --coverage</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --crashdump --crashdump-type mini</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 10m --hangdump-type mini</TestingPlatformCommandLineArguments>
@@ -36,7 +68,9 @@
 
   <!-- VSTest -->
   <ItemGroup Condition="!('$(UseMicrosoftTestingPlatform)' == 'true' OR ('$(UseMicrosoftTestingPlatform)' == '' AND (
+                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3')) == 'true' OR
                          @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.mtp-v2')) == 'true' OR
+                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-v2')) == 'true' OR
                          @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'TUnit')) == 'true'
                          )))">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" IsImplicitlyDefined="true" />
@@ -56,7 +90,7 @@
     <VSTestSetting Condition="'$(EnableCodeCoverage)' == 'true'">$(MSBuildThisFileDirectory)../configuration/default.runsettings</VSTestSetting>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(EnableDefaultTestSettings)' != 'false'">
     <VSTestLogger Condition="'$(VSTestLogger)' != ''">$(VSTestLogger);</VSTestLogger>
     <VSTestLogger>$(VSTestLogger)trx;console%3bverbosity=normal</VSTestLogger>
   </PropertyGroup>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -28,7 +28,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     private static readonly NuGetReference[] XUnit3References =
     [
         new NuGetReference("xunit.v3", "4.0.0"),
-        new NuGetReference("xunit.runner.visualstudio", "4.0.0"),
     ];
     private static readonly NuGetReference[] XUnit3MTP2References =
     [
@@ -1278,6 +1277,202 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task MTP_DefaultTestFramework_AddsXunit()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.True(data.IsMSBuildTargetExecuted("_MTPBuild"));
+
+        var packageReferences = data.GetMSBuildItems("PackageReference");
+        Assert.Contains("xunit.v3.mtp-v2", packageReferences, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Microsoft.NET.Test.Sdk", packageReferences, StringComparer.OrdinalIgnoreCase);
+        Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task MTP_DefaultTestFramework_NotAddedWhenAnotherFrameworkIsReferenced()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            nuGetPackages: [.. TUnitReferences]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Test]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("xunit.v3.mtp-v2", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MTP_DefaultTestFramework_OptOut()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("EnableDefaultTestFramework", "false")],
+            nuGetPackages: [.. XUnit2References]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+
+        var packageReferences = data.GetMSBuildItems("PackageReference");
+        Assert.DoesNotContain("xunit.v3.mtp-v2", packageReferences, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("Microsoft.NET.Test.Sdk", packageReferences, StringComparer.OrdinalIgnoreCase);
+    }
+
+    // 'dotnet test' renders the results itself in MTP mode, so '--output Detailed' must be set on the command line.
+    // The default arguments added by the SDK must not conflict with it.
+    [Fact]
+    public async Task MTP_DetailedOutputListsSucceededTests()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            nuGetPackages: [.. XUnit3References]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void SampleSucceedingTest()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput(["--output", "Detailed"]);
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.True(data.OutputContains("SampleSucceedingTest", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MTP_GitHubActionsReport()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput(environmentVariables: [.. project.GitHubEnvironmentVariables]);
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.NotEmpty(project.GetGitHubStepSummaryContent());
+    }
+
+    [Fact]
+    public async Task MTP_GitHubActionsReport_OptOut()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("EnableGitHubActionsReport", "false")]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput(environmentVariables: [.. project.GitHubEnvironmentVariables]);
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("Microsoft.Testing.Extensions.GitHubActionsReport", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+        Assert.Empty(project.GetGitHubStepSummaryContent());
+    }
+
+    [Fact]
     public async Task CentralPackageManagement()
     {
         await using var project = CreateProjectBuilder();
@@ -1287,7 +1482,13 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
             );
 
         project.AddFile("Program.cs", """
-            Console.WriteLine();
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
             """);
 
         project.AddFile("Directory.Packages.props", """
@@ -1577,7 +1778,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     public async Task AssemblyContainsMetadataAttributeWithSdkName(string sdkName)
     {
         await using var project = CreateProjectBuilder(sdkName);
-        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+        project.AddCsprojFile(filename: "Sample.Tests.csproj", properties: [("EnableDefaultTestFramework", "false")]);
 
         project.AddDirectoryBuildPropsFile(postSdkContent: "");
 


### PR DESCRIPTION
`Meziantou.NET.Sdk.Test` only *reacted* to whatever test framework a project already referenced — it never added one — so every consumer repeated the same `xunit.v3` / `xunit.runner.visualstudio` / `Microsoft.NET.Test.Sdk` block. The Test SDK is now opinionated like the rest of the SDK: reference it, write a `[Fact]`, run `dotnet test`.

```xml
<Project Sdk="Meziantou.NET.Sdk.Test">
</Project>
```

## What changed

All build changes are in `src/common/Tests.targets` — `src/Sdk/**`, the `.csproj`s and the `.nuspec`s are generated by `tools/SdkGenerator` and were not touched.

- **Default test framework.** Adds `xunit.v3.mtp-v2` 4.0.0 when the project references no test framework (`xunit`, `xunit.v3*`, `TUnit`, `MSTest`, `NUnit` all suppress it). In xunit 4.0 `xunit.v3` is a metapackage over `xunit.v3.mtp-v2` and MTP v1 support was removed, so this *is* MTP v2 — pinned explicitly so a future xunit release can't silently move the MTP major version.
- **`OutputType` defaults to `Exe`.** `xunit.v3.core.mtp-v2` hard-errors when it isn't (`_XunitValidateBuild`). `UseMicrosoftTestingPlatformRunner` defaults to `true` so the test executable uses the MTP command line rather than xunit's own console runner.
- **GitHub Actions reports.** Adds `Microsoft.Testing.Extensions.GitHubActionsReport` and `--report-gh`, giving per-assembly log groups, failed/skipped test annotations and a Markdown job summary. The extension is inert unless `GITHUB_ACTIONS=true`.
- **Bug fix.** `529dcf3` added `xunit.v3` to the MTP condition but not to the VSTest exclusion, so a project referencing `xunit.v3` got the six MTP extensions **and** `Microsoft.NET.Test.Sdk` — running MTP under VSTest is unsupported with MTP v2 on the .NET 10 SDK. Both conditions now match, and cover `xunit.v3.core.mtp-v2`.
- **Two consistency fixes.** `IsPackable` was assigned unconditionally, silently overriding a project that sets it (`Tests.targets` is imported after the project body). The `VSTestLogger` block was the one default with no `EnableDefaultTestSettings` opt-out.

New opt-outs, both defaulting to `true`: `EnableDefaultTestFramework` and `EnableGitHubActionsReport`.

## Note for reviewers

**`--output Detailed` cannot be set from the project file.** I shipped it, the test failed, and I reproduced it standalone: in MTP mode `dotnet test` renders the results itself, so `TestingPlatformCommandLineArguments` reaches the test app (where it's inert in server mode) while the CLI's own display stays `Normal`. Only `dotnet test --output Detailed` lists passing tests. Rather than ship a no-op argument, it's documented as a `dotnet test` flag in the README and covered by a test asserting the SDK's default arguments don't conflict with it.

**`Microsoft.Testing.Extensions.GitHubActionsReport` is prerelease.** nuget.org only has `1.0.0-alpha.26377.5` (a genuine Microsoft package, built from the same commit as MTP 2.3.3; the docs mark the extension as experimental). Renovate tracks alphas but won't jump from `1.0.0-alpha` to a future stable `2.x` — that needs a manual bump.

**Behavior change for existing consumers.** Test projects now default to `OutputType=Exe` and get an implicit xunit reference unless another framework is referenced. A project that must stay a library sets `EnableDefaultTestFramework=false`.

## Tests

6 new tests in `SdkTests.cs`: default framework added / not added when another framework is referenced / opt-out, detailed output, GitHub report, GitHub report opt-out. Verified end-to-end — the generated summary is a real report (`## ✅ Test Run Summary — Sample.Tests (net10.0)` with a Total/Passed/Failed/Skipped table and slowest tests).

`CentralPackageManagement` and `AssemblyContainsMetadataAttributeWithSdkName` needed fixing: their top-level-statement `Program.cs` now collides with xunit's generated entry point. `XUnit3References` had been dead since `e1a843d`; it's now used and trimmed to `xunit.v3` alone.

Full suite: **294 passed, 0 failed** across both the `Sdk10_0_Root_Tests` and `Sdk11_0_Root_Tests` subclasses.

*Generated with [Claude Code](https://claude.com/claude-code)*