### PR TITLE
Report MA0002 only for non-ordinal string comparisons

### DIFF
--- a/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
@@ -2,6 +2,7 @@
 is_global = true
 global_level = 0
 
+MA0002.report_only_non_ordinal = true
 MA0015.consider_member_access_as_parameter = true
 
 # MA0001: StringComparison is missing


### PR DESCRIPTION
## What

Set `MA0002.report_only_non_ordinal = true` in `src/configuration/Analyzer.Meziantou.Analyzer.editorconfig`.

## Why

MA0002 (*`IEqualityComparer<string>` or `IComparer<string>` is missing*) currently reports every string-keyed collection, including the many cases where the default comparison is already ordinal and therefore correct. With `report_only_non_ordinal`, the diagnostic is limited to the cases where the default comparison would be culture-sensitive — which is where the bugs actually are.

The rule severity is unchanged (`warning`).

## Reviewer notes

The option is placed at the top of the file, before the first rule block, alongside the existing `MA0015.consider_member_access_as_parameter` option. That placement is load-bearing: `ConfigFilesGenerator` regenerates this file from the analyzer assembly and only preserves non-`dotnet_diagnostic.*.severity` lines that appear before the first rule (`tools/ConfigFilesGenerator/Program.cs:606`). An option placed further down would be silently dropped on the next regeneration.

## Verification

- `dotnet build Meziantou.NET.Sdk.slnx` — succeeded, 0 warnings, 0 errors
- `dotnet test tests/Meziantou.Sdk.Tests` — 312 passed, 0 failed, 0 skipped