### PR TITLE
Ban Meziantou.Xunit.ParallelTestFramework packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The SDK also blocks selected NuGet packages by default:
 - `YamlDotNet` (use `Meziantou.Framework.Yaml`)
 - `CliWrap` (use `Meziantou.Framework.ProcessWrapper`)
 - `Testcontainers` (use `Meziantou.Framework.TemporaryContainers`)
+- `Meziantou.Xunit.ParallelTestFramework` (use the built-in parallelization of xunit.v3)
+- `Meziantou.Xunit.v3.ParallelTestFramework` (use the built-in parallelization of xunit.v3)
 
 | Property | Default | Description |
 | --- | --- | --- |
@@ -144,6 +146,8 @@ The SDK also blocks selected NuGet packages by default:
 | `AllowPackage_YamlDotNet` | unset (`false`) | Allows `YamlDotNet` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.Yaml`. |
 | `AllowPackage_CliWrap` | unset (`false`) | Allows `CliWrap` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.ProcessWrapper`. |
 | `AllowPackage_Testcontainers` | unset (`false`) | Allows `Testcontainers` when set to `true`; otherwise the build fails and suggests `Meziantou.Framework.TemporaryContainers`. |
+| `AllowPackage_Meziantou_Xunit_ParallelTestFramework` | unset (`false`) | Allows `Meziantou.Xunit.ParallelTestFramework` when set to `true`; otherwise the build fails and suggests the built-in parallelization of xunit.v3. |
+| `AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework` | unset (`false`) | Allows `Meziantou.Xunit.v3.ParallelTestFramework` when set to `true`; otherwise the build fails and suggests the built-in parallelization of xunit.v3. |
 | `Disable_SponsorLink` | `true` | Removes SponsorLink and Moq analyzers when not set to `false`. |
 
 ## Web SDK and containers

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -130,6 +130,10 @@
 		       Condition="'$(AllowPackage_CliWrap)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'CliWrap')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'CliWrap')) == 'true')" />
 		<Error Text="Package 'Testcontainers' is not allowed. Use 'Meziantou.Framework.TemporaryContainers' instead. To allow this package, set 'AllowPackage_Testcontainers=true'."
 		       Condition="'$(AllowPackage_Testcontainers)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'Testcontainers')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'Testcontainers')) == 'true')" />
+		<Error Text="Package 'Meziantou.Xunit.ParallelTestFramework' is not allowed. Use the built-in parallelization of xunit.v3 instead. To allow this package, set 'AllowPackage_Meziantou_Xunit_ParallelTestFramework=true'."
+		       Condition="'$(AllowPackage_Meziantou_Xunit_ParallelTestFramework)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'Meziantou.Xunit.ParallelTestFramework')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'Meziantou.Xunit.ParallelTestFramework')) == 'true')" />
+		<Error Text="Package 'Meziantou.Xunit.v3.ParallelTestFramework' is not allowed. Use the built-in parallelization of xunit.v3 instead. To allow this package, set 'AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework=true'."
+		       Condition="'$(AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'Meziantou.Xunit.v3.ParallelTestFramework')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'Meziantou.Xunit.v3.ParallelTestFramework')) == 'true')" />
 	</Target>
 
 	<!-- NuGet Package -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -690,10 +690,12 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Theory]
-    [InlineData("YamlDotNet", "16.3.0", "Meziantou.Framework.Yaml", "AllowPackage_YamlDotNet")]
-    [InlineData("CliWrap", "3.7.0", "Meziantou.Framework.ProcessWrapper", "AllowPackage_CliWrap")]
-    [InlineData("Testcontainers", "4.13.0", "Meziantou.Framework.TemporaryContainers", "AllowPackage_Testcontainers")]
-    public async Task BannedPackageReference_DirectReference_IsReported(string packageName, string packageVersion, string suggestedPackage, string allowProperty)
+    [InlineData("YamlDotNet", "16.3.0", "'Meziantou.Framework.Yaml'", "AllowPackage_YamlDotNet")]
+    [InlineData("CliWrap", "3.7.0", "'Meziantou.Framework.ProcessWrapper'", "AllowPackage_CliWrap")]
+    [InlineData("Testcontainers", "4.13.0", "'Meziantou.Framework.TemporaryContainers'", "AllowPackage_Testcontainers")]
+    [InlineData("Meziantou.Xunit.ParallelTestFramework", "2.3.0", "the built-in parallelization of xunit.v3", "AllowPackage_Meziantou_Xunit_ParallelTestFramework")]
+    [InlineData("Meziantou.Xunit.v3.ParallelTestFramework", "1.0.6", "the built-in parallelization of xunit.v3", "AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework")]
+    public async Task BannedPackageReference_DirectReference_IsReported(string packageName, string packageVersion, string suggestion, string allowProperty)
     {
         await using var project = CreateProjectBuilder();
         project.AddCsprojFile(properties: [("TargetFramework", "net10.0")], nuGetPackages: [new NuGetReference(packageName, packageVersion)]);
@@ -702,15 +704,17 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
 
         Assert.Equal(1, data.ExitCode);
         Assert.True(data.OutputContains($"Package '{packageName}' is not allowed.", StringComparison.Ordinal));
-        Assert.True(data.OutputContains($"Use '{suggestedPackage}' instead.", StringComparison.Ordinal));
+        Assert.True(data.OutputContains($"Use {suggestion} instead.", StringComparison.Ordinal));
         Assert.True(data.OutputContains($"{allowProperty}=true", StringComparison.Ordinal));
     }
 
     [Theory]
-    [InlineData("YamlDotNet", "16.3.0", "Meziantou.Framework.Yaml", "AllowPackage_YamlDotNet")]
-    [InlineData("CliWrap", "3.7.0", "Meziantou.Framework.ProcessWrapper", "AllowPackage_CliWrap")]
-    [InlineData("Testcontainers", "4.13.0", "Meziantou.Framework.TemporaryContainers", "AllowPackage_Testcontainers")]
-    public async Task BannedPackageReference_TransitiveReference_IsReported(string packageName, string packageVersion, string suggestedPackage, string allowProperty)
+    [InlineData("YamlDotNet", "16.3.0", "'Meziantou.Framework.Yaml'", "AllowPackage_YamlDotNet")]
+    [InlineData("CliWrap", "3.7.0", "'Meziantou.Framework.ProcessWrapper'", "AllowPackage_CliWrap")]
+    [InlineData("Testcontainers", "4.13.0", "'Meziantou.Framework.TemporaryContainers'", "AllowPackage_Testcontainers")]
+    [InlineData("Meziantou.Xunit.ParallelTestFramework", "2.3.0", "the built-in parallelization of xunit.v3", "AllowPackage_Meziantou_Xunit_ParallelTestFramework")]
+    [InlineData("Meziantou.Xunit.v3.ParallelTestFramework", "1.0.6", "the built-in parallelization of xunit.v3", "AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework")]
+    public async Task BannedPackageReference_TransitiveReference_IsReported(string packageName, string packageVersion, string suggestion, string allowProperty)
     {
         await using var project = CreateProjectBuilder();
         project.AddFile("Dependency/Dependency.csproj", $$"""
@@ -733,7 +737,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
 
         Assert.Equal(1, data.ExitCode);
         Assert.True(data.OutputContains($"Package '{packageName}' is not allowed.", StringComparison.Ordinal));
-        Assert.True(data.OutputContains($"Use '{suggestedPackage}' instead.", StringComparison.Ordinal));
+        Assert.True(data.OutputContains($"Use {suggestion} instead.", StringComparison.Ordinal));
         Assert.True(data.OutputContains($"{allowProperty}=true", StringComparison.Ordinal));
     }
 
@@ -741,6 +745,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     [InlineData("YamlDotNet", "16.3.0", "AllowPackage_YamlDotNet")]
     [InlineData("CliWrap", "3.7.0", "AllowPackage_CliWrap")]
     [InlineData("Testcontainers", "4.13.0", "AllowPackage_Testcontainers")]
+    [InlineData("Meziantou.Xunit.ParallelTestFramework", "2.3.0", "AllowPackage_Meziantou_Xunit_ParallelTestFramework")]
+    [InlineData("Meziantou.Xunit.v3.ParallelTestFramework", "1.0.6", "AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework")]
     public async Task BannedPackageReference_CanBeAllowedPerPackage(string packageName, string packageVersion, string allowProperty)
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
## What

Adds `Meziantou.Xunit.ParallelTestFramework` and `Meziantou.Xunit.v3.ParallelTestFramework` to the SDK's banned package list, suggesting the built-in parallelization of xunit.v3 instead.

## Why

xunit.v3 parallelizes test cases within a class natively, which is what these packages were built to provide for xunit v2. Referencing them on top of xunit.v3 is redundant.

## Changes

- `src/common/Common.targets` — two new `Error` entries in `FailOnBannedPackageReferences`, matching both direct `PackageReference` and transitive `ReferencePath` like the existing bans:

  ```
  Package 'Meziantou.Xunit.ParallelTestFramework' is not allowed. Use the built-in parallelization of xunit.v3 instead. To allow this package, set 'AllowPackage_Meziantou_Xunit_ParallelTestFramework=true'.
  ```

- `tests/Meziantou.Sdk.Tests/SdkTests.cs` — new `InlineData` rows on the three existing banned-package theories (direct reference, transitive reference, per-package opt-out).
- `README.md` — documents both packages and their `AllowPackage_*` properties.

## Reviewer notes

- The escape-hatch properties use underscores (`AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework`) because MSBuild property names cannot contain dots.
- `BannedPackageReference_*_IsReported` previously took a `suggestedPackage` parameter and asserted `Use '{suggestedPackage}' instead.`. Since the new suggestion is a feature rather than a package, the parameter is now `suggestion` and carries the full replacement phrase — the existing rows pass `'Meziantou.Framework.Yaml'` etc. with the quotes included, so the assertion text is unchanged for them.

## Testing

`--filter-method "*.BannedPackageReference_*"` — 30 passed, 0 failed (5 packages × 3 scenarios × 2 SDK versions).