### PR TITLE
Remove xUnit.net v2 from the SDK tests

### DIFF
--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -20,10 +20,10 @@ public sealed class Sdk11_0_Root_Tests(PackageFixture fixture, ITestOutputHelper
 public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOutputHelper, NetSdkVersion dotnetSdkVersion)
 {
     // note: don't simplify names as they are used in the Renovate regex
-    private static readonly NuGetReference[] XUnit2References =
+    private static readonly NuGetReference[] XUnit3VSTestReferences =
     [
-        new NuGetReference("xunit", "2.9.3"),
-        new NuGetReference("xunit.runner.visualstudio", "3.1.5"),
+        new NuGetReference("xunit.v3.mtp-off", "4.0.0"),
+        new NuGetReference("xunit.runner.visualstudio", "4.0.0"),
     ];
     private static readonly NuGetReference[] XUnit3References =
     [
@@ -992,8 +992,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     {
         await using var project = CreateProjectBuilder();
         project.AddCsprojFile(
-            properties: [("IsTestProject", "true")],
-            nuGetPackages: [.. XUnit2References]
+            properties: [("IsTestProject", "true"), ("UseMicrosoftTestingPlatformRunner", "false")],
+            nuGetPackages: [.. XUnit3VSTestReferences]
         );
         project.AddFile("sample.cs", """
             public class Sample
@@ -1014,8 +1014,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     {
         await using var project = CreateProjectBuilder();
         project.AddCsprojFile(
-            properties: [("IsTestProject", "true"), ("OptimizeVsTestRun", "false")],
-            nuGetPackages: [.. XUnit2References]
+            properties: [("IsTestProject", "true"), ("OptimizeVsTestRun", "false"), ("UseMicrosoftTestingPlatformRunner", "false")],
+            nuGetPackages: [.. XUnit3VSTestReferences]
         );
         project.AddFile("sample.cs", """
             public class Sample
@@ -1084,16 +1084,18 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. XUnit2References]
+            properties: [("UseMicrosoftTestingPlatformRunner", "false")],
+            nuGetPackages: [.. XUnit3VSTestReferences]
             );
 
+        // 'xunit.v3.mtp-off' doesn't add the implicit using for 'Xunit', so the names must be fully qualified
         project.AddFile("Program.cs", """
             public class Tests
             {
-                [Fact]
+                [Xunit.Fact]
                 public void Test1()
                 {
-                    Assert.Fail("failure message");
+                    Xunit.Assert.Fail("failure message");
                 }
             }
             """);
@@ -1357,13 +1359,14 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
             properties: [("EnableDefaultTestFramework", "false")],
-            nuGetPackages: [.. XUnit2References]
+            nuGetPackages: [.. XUnit3VSTestReferences]
             );
 
+        // 'xunit.v3.mtp-off' doesn't add the implicit using for 'Xunit', so the names must be fully qualified
         project.AddFile("Program.cs", """
             public class Tests
             {
-                [Fact]
+                [Xunit.Fact]
                 public void Test1()
                 {
                 }
@@ -1436,33 +1439,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
 
         Assert.Equal(0, data.ExitCode);
         Assert.False(data.IsMSBuildTargetExecuted("GenerateXunitParallelizationSourceFile"));
-        Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitParallelization", StringComparison.Ordinal));
-    }
-
-    // 'Xunit.v3.ParallelizationAttribute' doesn't exist in xUnit.net v2, so the file must not be generated
-    [Fact]
-    public async Task MTP_XunitFullParallelization_NotGeneratedForXunitV2()
-    {
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            properties: [("EnableDefaultTestFramework", "false")],
-            nuGetPackages: [.. XUnit2References]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Fact]
-                public void Test1()
-                {
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput();
-
-        Assert.Equal(0, data.ExitCode);
         Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitParallelization", StringComparison.Ordinal));
     }
 
@@ -1592,33 +1568,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
 
         Assert.Equal(0, data.ExitCode);
         Assert.False(data.IsMSBuildTargetExecuted("GenerateXunitStaticHelpersSourceFile"));
-        Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitStaticHelpers", StringComparison.Ordinal));
-    }
-
-    // 'Xunit.TestContext' doesn't exist in xUnit.net v2, so the file must not be generated
-    [Fact]
-    public async Task MTP_XunitStaticHelpers_NotGeneratedForXunitV2()
-    {
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            properties: [("EnableDefaultTestFramework", "false")],
-            nuGetPackages: [.. XUnit2References]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Fact]
-                public void Test1()
-                {
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput();
-
-        Assert.Equal(0, data.ExitCode);
         Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitStaticHelpers", StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## What

Removes every usage of xUnit.net v2 from `tests/Meziantou.Sdk.Tests/SdkTests.cs`. The test suite now only uses xUnit.net v3 packages.

- Replaced `XUnit2References` (`xunit` 2.9.3 + `xunit.runner.visualstudio` 3.1.5) with `XUnit3VSTestReferences` (`xunit.v3.mtp-off` 4.0.0 + `xunit.runner.visualstudio` 4.0.0).
- Ported the 4 tests that used xUnit.net v2 only as a test framework: `DotnetTestSkipAnalyzers`, `DotnetTestSkipAnalyzers_OptOut`, `VSTests_OnUnknownContextShouldNotAddCustomLogger`, `MTP_DefaultTestFramework_OptOut`.
- Deleted the 2 tests that only asserted xUnit.net v2 behaviors: `MTP_XunitFullParallelization_NotGeneratedForXunitV2` and `MTP_XunitStaticHelpers_NotGeneratedForXunitV2`.

## Why

`xunit.v3.mtp-off` is the v3 variant that is not MTP-aware, so `Tests.targets` keeps routing those projects to the VSTest code path (`Microsoft.NET.Test.Sdk`, the `VSTest` target, the trx logger). Using it instead of xUnit.net v2 preserves the exact SDK branch each ported test was covering, so no coverage is lost.

The two deleted tests only asserted that `Meziantou.NET.Sdk.XunitParallelization.g.cs` / `Meziantou.NET.Sdk.XunitStaticHelpers.g.cs` are not generated for xUnit.net v2. The `MTP_XunitFullParallelization_NotGeneratedForAnotherTestFramework` and `MTP_XunitStaticHelpers_NotGeneratedForAnotherTestFramework` tests (TUnit) still cover the "not generated for a non-v3 framework" case.

## Notes for reviewers

Two adjustments were required by the v3 packages:

- `UseMicrosoftTestingPlatformRunner` is set to `false` on the ported projects where `Tests.targets` would otherwise set it to `true`: `xunit.v3.core.mtp-off` raises an error when that property is `true`.
- The generated sources use fully qualified `Xunit.Fact` / `Xunit.Assert`, because the implicit `using Xunit` in `Tests.targets` is only added for `xunit`, `xunit.v3`, `xunit.v3.mtp-v1`, and `xunit.v3.mtp-v2` — not for the `mtp-off` variants.

No change was needed under `src/`: `Tests.targets` still recognizes `xunit` 2.x as a referenced test framework, which remains correct for consumers.

## Validation

- `dotnet build tests/Meziantou.Sdk.Tests` succeeds with 0 warnings.
- The 4 ported tests (plus `MTP_DotnetTestSkipAnalyzers`) pass: 10/10 across both SDK versions.
- The `*Xunit*` method filter passes: 16/16.

The full suite was not run locally; the change is confined to that single test file.