### PR TITLE
Add MinimumExpectedTests to configure --minimum-expected-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ the missing `partial` modifier:
 | `EnableXunitStaticHelpers` | Auto | Generates the `Meziantou.NET.Sdk.Test.XUnitStaticHelpers` static class exposing `XunitCancellationToken` (`TestContext.Current.CancellationToken`). Generated when an xUnit.net v3 package is referenced, when set to `true` whatever the referenced packages are, and never when set to `false`. The global `using static` directive requires `ImplicitUsings`. |
 | `EnableGitHubActionsReport` | `true` | Adds `Microsoft.Testing.Extensions.GitHubActionsReport` and `--report-gh`. The extension is inert unless the build runs on GitHub Actions. |
 | `EnableCodeCoverage` | `true` on CI | Enables code coverage collection on CI. |
+| `EnableMinimumExpectedTests` | `true` | Adds `--minimum-expected-tests 1`. Set it to `false` when the project sets its own value in `TestingPlatformCommandLineArguments`. Note that Microsoft.Testing.Platform expects at least one test to run even when the argument is not set. |
 | `OptimizeVsTestRun` | `true` | Disables analyzers during `dotnet test` unless set to `false`. |
 | `UseMicrosoftTestingPlatform` | Auto | Uses MTP when set to `true` or when `xunit.v3`, `xunit.v3.mtp-v2`, `xunit.v3.core.mtp-v2`, or `TUnit` is referenced. `Microsoft.NET.Test.Sdk` is added only when MTP is not used. |
 | `EnableDefaultTestSettings` | `true` | Adds default crash/hang dumps and loggers. |

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ the missing `partial` modifier:
 | `EnableXunitStaticHelpers` | Auto | Generates the `Meziantou.NET.Sdk.Test.XUnitStaticHelpers` static class exposing `XunitCancellationToken` (`TestContext.Current.CancellationToken`). Generated when an xUnit.net v3 package is referenced, when set to `true` whatever the referenced packages are, and never when set to `false`. The global `using static` directive requires `ImplicitUsings`. |
 | `EnableGitHubActionsReport` | `true` | Adds `Microsoft.Testing.Extensions.GitHubActionsReport` and `--report-gh`. The extension is inert unless the build runs on GitHub Actions. |
 | `EnableCodeCoverage` | `true` on CI | Enables code coverage collection on CI. |
-| `EnableMinimumExpectedTests` | `true` | Adds `--minimum-expected-tests 1`. Set it to `false` when the project sets its own value in `TestingPlatformCommandLineArguments`. Note that Microsoft.Testing.Platform expects at least one test to run even when the argument is not set. |
+| `MinimumExpectedTests` | `1` | Sets `--minimum-expected-tests`, the number of tests that must run for the test run to succeed. Set it to `0` to not set the argument, as Microsoft.Testing.Platform only accepts a non-zero positive value. Note that the platform still expects at least one test to run when the argument is not set. |
 | `OptimizeVsTestRun` | `true` | Disables analyzers during `dotnet test` unless set to `false`. |
 | `UseMicrosoftTestingPlatform` | Auto | Uses MTP when set to `true` or when `xunit.v3`, `xunit.v3.mtp-v2`, `xunit.v3.core.mtp-v2`, or `TUnit` is referenced. `Microsoft.NET.Test.Sdk` is added only when MTP is not used. |
 | `EnableDefaultTestSettings` | `true` | Adds default crash/hang dumps and loggers. |

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -63,7 +63,9 @@
     <TestingPlatformCommandLineArguments Condition="'$(EnableCodeCoverage)' == 'true'">$(TestingPlatformCommandLineArguments) --coverage</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --crashdump --crashdump-type mini</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 10m --hangdump-type mini</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --minimum-expected-tests 1</TestingPlatformCommandLineArguments>
+    <!-- Set 'EnableMinimumExpectedTests' to 'false' to not set the argument, for instance when the project sets
+         its own value in 'TestingPlatformCommandLineArguments' -->
+    <TestingPlatformCommandLineArguments Condition="'$(EnableMinimumExpectedTests)' != 'false'">$(TestingPlatformCommandLineArguments) --minimum-expected-tests 1</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <!-- VSTest -->

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -6,6 +6,7 @@
     <EnableCodeCoverage Condition="'$(EnableCodeCoverage)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">true</EnableCodeCoverage>
     <EnableDefaultTestFramework Condition="'$(EnableDefaultTestFramework)' == ''">true</EnableDefaultTestFramework>
     <EnableGitHubActionsReport Condition="'$(EnableGitHubActionsReport)' == ''">true</EnableGitHubActionsReport>
+    <MinimumExpectedTests Condition="'$(MinimumExpectedTests)' == ''">1</MinimumExpectedTests>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnableDefaultTestFramework)' == 'true'">
@@ -63,9 +64,8 @@
     <TestingPlatformCommandLineArguments Condition="'$(EnableCodeCoverage)' == 'true'">$(TestingPlatformCommandLineArguments) --coverage</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --crashdump --crashdump-type mini</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 10m --hangdump-type mini</TestingPlatformCommandLineArguments>
-    <!-- Set 'EnableMinimumExpectedTests' to 'false' to not set the argument, for instance when the project sets
-         its own value in 'TestingPlatformCommandLineArguments' -->
-    <TestingPlatformCommandLineArguments Condition="'$(EnableMinimumExpectedTests)' != 'false'">$(TestingPlatformCommandLineArguments) --minimum-expected-tests 1</TestingPlatformCommandLineArguments>
+    <!-- Microsoft.Testing.Platform only accepts a non-zero positive value, so the argument is not set when 'MinimumExpectedTests' is '0' -->
+    <TestingPlatformCommandLineArguments Condition="'$(MinimumExpectedTests)' != '' AND '$(MinimumExpectedTests)' != '0'">$(TestingPlatformCommandLineArguments) --minimum-expected-tests $(MinimumExpectedTests)</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <!-- VSTest -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1778,12 +1778,12 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task MTP_MinimumExpectedTests_OptOut()
+    public async Task MTP_MinimumExpectedTests_CustomValue()
     {
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
-            properties: [("EnableMinimumExpectedTests", "false")]
+            properties: [("MinimumExpectedTests", "2")]
             );
 
         project.AddFile("Program.cs", """
@@ -1796,7 +1796,50 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
             }
             """);
 
-        var data = await project.BuildAndGetOutput();
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(9, data.ExitCode);
+        Assert.Contains("--minimum-expected-tests 2", data.GetMSBuildPropertyValue("TestingPlatformCommandLineArguments"), StringComparison.Ordinal);
+    }
+
+    // Microsoft.Testing.Platform reports an invalid command line when '--minimum-expected-tests' is set to '0',
+    // so the argument must not be set at all
+    [Fact]
+    public async Task MTP_MinimumExpectedTests_Zero()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("MinimumExpectedTests", "0")]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
         Assert.DoesNotContain("--minimum-expected-tests", data.GetMSBuildPropertyValue("TestingPlatformCommandLineArguments"), StringComparison.Ordinal);

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1756,6 +1756,53 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task MTP_MinimumExpectedTests()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Contains("--minimum-expected-tests 1", data.GetMSBuildPropertyValue("TestingPlatformCommandLineArguments"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MTP_MinimumExpectedTests_OptOut()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("EnableMinimumExpectedTests", "false")]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("--minimum-expected-tests", data.GetMSBuildPropertyValue("TestingPlatformCommandLineArguments"), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CentralPackageManagement()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
The test SDK unconditionally appended `--minimum-expected-tests 1` to `TestingPlatformCommandLineArguments`, so a project could not set its own value without the argument being specified twice.

## Changes

- `src/common/Tests.targets`: new `MinimumExpectedTests` property, defaulting to `1`, whose value is passed to `--minimum-expected-tests`. The argument is not added when the property is `0` or empty.
- `README.md`: documents the new property in the test options table.
- `tests/Meziantou.Sdk.Tests/SdkTests.cs`: `MTP_MinimumExpectedTests` (default), `MTP_MinimumExpectedTests_CustomValue` (a project with a single test and `MinimumExpectedTests` set to `2` exits with the code 9) and `MTP_MinimumExpectedTests_Zero` (the argument is not set).

## Notes for reviewers

Microsoft.Testing.Platform rejects `--minimum-expected-tests 0` (`'--minimum-expected-tests' expects a single non-zero positive integer value`, exit code 5), so `0` means "don't set the argument" rather than "allow a run with zero tests". The platform expects at least one test to run even when the argument is not set, so a test run executing no test still fails with the exit code 8.

```xml
<PropertyGroup>
  <MinimumExpectedTests>10</MinimumExpectedTests>
</PropertyGroup>
```

## Validation

`dotnet build` succeeds and all 50 `MTP_*` tests pass (25 per SDK variant, including the 6 for this feature).