### PR TITLE
Use Meziantou.Framework.Assertions as the default assertion library

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,30 @@ already references `xunit`, `xunit.v3*`, `TUnit`, `MSTest`, or `NUnit`. Set
 `EnableDefaultTestFramework` to `false` for full control, which is also required for a test project
 that must stay a library (VSTest).
 
+The assertions come from
+[`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions)
+instead of xUnit.net. The SDK adds the package and generates the
+`global using Assert = Meziantou.Framework.Assertions.Assert;` alias, so `Assert` refers to it in any test
+— a using alias takes precedence over the namespaces imported in the same scope, so it wins over the
+global `using Xunit;` directive:
+
+````csharp
+[Fact]
+public void Sample() => Assert.HasCount(2, new[] { 1, 2 });
+````
+
+Only the meaning of `Assert` changes: the assertions of the test framework stay available under their
+full name, such as `Xunit.Assert`. This happens when the SDK adds the default test framework itself and
+the project targets .NET 10 or later, as the package supports no older framework. Set
+`EnableMeziantouAssertions` to `true` to add it whatever the referenced packages and the target framework
+are, or to `false` to opt out and keep the assertions of the test framework:
+
+````xml
+<PropertyGroup>
+  <EnableMeziantouAssertions>false</EnableMeziantouAssertions>
+</PropertyGroup>
+````
+
 xUnit.net v3 runs test collections in parallel, but the tests inside a collection run one after the
 other. When the project resolves xUnit.net v3 4.0 or later, the SDK generates a source file that opts
 the whole assembly into
@@ -276,6 +300,7 @@ the missing `partial` modifier:
 | Property | Default | Description |
 | --- | --- | --- |
 | `EnableDefaultTestFramework` | `true` | Adds `xunit.v3.mtp-v2` when no test framework is referenced, sets `OutputType` to `Exe` (required by xUnit.net v3) and `UseMicrosoftTestingPlatformRunner` to `true`. |
+| `EnableMeziantouAssertions` | Auto | Adds `Meziantou.Framework.Assertions` and aliases `Assert` to `Meziantou.Framework.Assertions.Assert`. Added when the SDK adds the default test framework and the project targets .NET 10 or later, when set to `true` whatever the referenced packages and the target framework are, and never when set to `false`. |
 | `EnableXunitFullParallelization` | Auto | Generates a source file with `[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.All)]` so every test runs in parallel, not just test collections. Generated when xUnit.net v3 4.0 or later is resolved, when set to `true` whatever the resolved references are, and never when set to `false`. |
 | `XunitParallelizationMode` | `All` | Sets the `Xunit.Sdk.ParallelMode` value used by the generated attribute: `None`, `Collections` or `All`. Setting it also generates the source file whatever the resolved references are. The file is not generated when `EnableXunitFullParallelization` is `false`. |
 | `EnableXunitStaticHelpers` | Auto | Generates the `Meziantou.NET.Sdk.Test.XUnitStaticHelpers` static class exposing `XunitCancellationToken` (`TestContext.Current.CancellationToken`). Generated when an xUnit.net v3 package is referenced, when set to `true` whatever the referenced packages are, and never when set to `false`. The global `using static` directive requires `ImplicitUsings`. |

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -1,10 +1,12 @@
 ﻿<Project>
-	<Import Project="$(MSBuildThisFileDirectory)/Tests.targets" Condition="'$(IsTestProject)' == 'true'" />
-	<Import Project="$(MSBuildThisFileDirectory)/Npm.targets" />
-
+	<!-- The default target framework must be set before importing 'Tests.targets', as it uses it to
+	     determine which packages are compatible with the project -->
 	<PropertyGroup>
 		<TargetFramework Condition="'$(TargetFramework)' == '' AND '$(TargetFrameworks)' == '' AND '$(NETCoreAppMaximumVersion)' != ''">net$(NETCoreAppMaximumVersion)</TargetFramework>
 	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)/Tests.targets" Condition="'$(IsTestProject)' == 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)/Npm.targets" />
 
 	<PropertyGroup>
     <GenerateSBOM Condition="'$(GenerateSBOM)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">true</GenerateSBOM>

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -40,6 +40,26 @@
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'MSTest.TestFramework')) != 'true' AND
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'NUnit')) != 'true'">
     <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0" IsImplicitlyDefined="true" />
+
+    <!-- An item is used instead of a property as item lists cannot be referenced in a property condition outside of a target (MSB4099) -->
+    <_DefaultTestFrameworkAdded Include="true" />
+  </ItemGroup>
+
+  <!-- Use 'Meziantou.Framework.Assertions' as the default assertion library -->
+  <!-- The package only supports .NET 10 and later, so it is added by default only when the SDK adds the default
+       test framework and the project targets a supported framework. Set 'EnableMeziantouAssertions' to 'true' to
+       add it whatever the referenced packages and the target framework are, or to 'false' to never add it. -->
+  <ItemGroup Condition="'$(EnableMeziantouAssertions)' == 'true' OR (
+                        '$(EnableMeziantouAssertions)' == '' AND
+                        '@(_DefaultTestFrameworkAdded)' == 'true' AND
+                        $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))
+                        )">
+    <PackageReference Include="Meziantou.Framework.Assertions" Version="2.0.2" IsImplicitlyDefined="true" />
+
+    <!-- 'Assert' must refer to 'Meziantou.Framework.Assertions.Assert', not to the one of the test framework.
+         A using alias takes precedence over the namespaces imported in the same scope, so the alias wins over
+         the global 'using Xunit;' directive. -->
+    <Using Include="Meziantou.Framework.Assertions.Assert" Alias="Assert" />
   </ItemGroup>
 
   <!-- MTP -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1383,6 +1383,188 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task MTP_MeziantouAssertions_AssertRefersToMeziantouAssertions()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+
+        // 'Assert' must be resolved to the Meziantou.Framework.Assertions type without any using directive
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1() => Assert.Equal(typeof(Meziantou.Framework.Assertions.Assert), typeof(Assert));
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Contains("Meziantou.Framework.Assertions", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("Meziantou.Framework.Assertions.Assert", data.GetMSBuildItems("Using"), StringComparer.Ordinal);
+    }
+
+    // Only the meaning of 'Assert' changes: the assertions of the test framework stay available
+    [Fact]
+    public async Task MTP_MeziantouAssertions_XunitAssertIsStillAvailable()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1() => Xunit.Assert.True(true);
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+    }
+
+    [Fact]
+    public async Task MTP_MeziantouAssertions_OptOut()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("EnableMeziantouAssertions", "false")]
+            );
+
+        // 'Assert' must still be resolved to the xUnit.net type
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1() => Assert.Equal(typeof(Xunit.Assert), typeof(Assert));
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("Meziantou.Framework.Assertions", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Meziantou.Framework.Assertions.Assert", data.GetMSBuildItems("Using"), StringComparer.Ordinal);
+    }
+
+    // The package must not replace the assertions of a test framework referenced by the project itself
+    [Fact]
+    public async Task MTP_MeziantouAssertions_NotAddedForAnotherTestFramework()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            nuGetPackages: [.. TUnitReferences]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Test]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("Meziantou.Framework.Assertions", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+    }
+
+    // The package only supports .NET 10 and later, so it must not break projects targeting an older framework
+    [Fact]
+    public async Task MTP_MeziantouAssertions_NotAddedForUnsupportedTargetFramework()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("TargetFramework", "net8.0")]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1() => Assert.Equal(typeof(Xunit.Assert), typeof(Assert));
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("Meziantou.Framework.Assertions", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+    }
+
+    // Setting the property explicitly adds the package even when the project references the test framework itself
+    [Fact]
+    public async Task MTP_MeziantouAssertions_ExplicitlyEnabled()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("EnableMeziantouAssertions", "true")],
+            nuGetPackages: [.. XUnit3References]
+            );
+
+        project.AddFile("Program.cs", """
+            public class Tests
+            {
+                [Fact]
+                public void Test1() => Assert.Equal(typeof(Meziantou.Framework.Assertions.Assert), typeof(Assert));
+            }
+            """);
+
+        project.AddFile("global.json", """
+            {
+                "test": {
+                    "runner": "Microsoft.Testing.Platform"
+                }
+            }
+            """);
+
+        var data = await project.TestAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Contains("Meziantou.Framework.Assertions", data.GetMSBuildItems("PackageReference"), StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task MTP_XunitFullParallelization_RunsTestsOfSameClassInParallelByDefault()
     {
         await using var project = CreateProjectBuilder(SdkTestName);


### PR DESCRIPTION
## What

When `Meziantou.NET.Sdk.Test` adds the default test framework, it now also adds [`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions) and generates a global alias so `Assert` refers to it:

```xml
<PackageReference Include="Meziantou.Framework.Assertions" Version="2.0.2" IsImplicitlyDefined="true" />
<Using Include="Meziantou.Framework.Assertions.Assert" Alias="Assert" />
```

```csharp
[Fact]
public void Sample() => Assert.HasCount(2, new[] { 1, 2 });
```

A using alias takes precedence over the namespaces imported in the same scope, so it wins over the global `using Xunit;` directive. Only the meaning of `Assert` changes — the assertions of the test framework stay available under their full name (`Xunit.Assert`).

`EnableMeziantouAssertions` is the opt-out:

| Value | Behavior |
| --- | --- |
| unset | Added when the SDK adds the default test framework and the project targets .NET 10 or later |
| `true` | Added whatever the referenced packages and the target framework are |
| `false` | Never added |

The target framework check uses `$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))`, as the package only ships `net10.0` and `net11.0` assemblies — a project targeting `net8.0` keeps the assertions of the test framework instead of failing to restore.

## Note for the reviewer

`Common.targets` now sets the default `TargetFramework` **before** importing `Tests.targets`. It was previously set after the import, so `$(TargetFramework)` was still empty inside `Tests.targets`. This was invisible until now: the .NET 11 SDK sets a default itself, so only the .NET 10 SDK test variants failed, which is what surfaced it.

The package ships analyzers `MFAS0001`-`MFAS0027`, several at **error** severity (such as `Assert.Same` on value types). Projects picking up this SDK version may start reporting those on assertions that compiled before.

## Tests

6 new tests in `SdkTests.cs` (12 runs, across the .NET 10 and .NET 11 SDK variants):

- `MTP_MeziantouAssertions_AssertRefersToMeziantouAssertions`
- `MTP_MeziantouAssertions_XunitAssertIsStillAvailable`
- `MTP_MeziantouAssertions_OptOut`
- `MTP_MeziantouAssertions_NotAddedForAnotherTestFramework`
- `MTP_MeziantouAssertions_NotAddedForUnsupportedTargetFramework`
- `MTP_MeziantouAssertions_ExplicitlyEnabled`

Full suite: 350 passed, 0 failed, 0 skipped.