### PR TITLE
Add the XUNIT_ENTRYPOINT_DISABLE_WARNINGS compilation constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ the missing `partial` modifier:
 </PropertyGroup>
 ````
 
+The SDK also defines the `XUNIT_ENTRYPOINT_DISABLE_WARNINGS` compilation constant in every test project:
+
+````csharp
+#if XUNIT_ENTRYPOINT_DISABLE_WARNINGS
+// ...
+#endif
+````
+
+Set `EnableXunitEntryPointDisableWarnings` to `false` to not define it:
+
+````xml
+<PropertyGroup>
+  <EnableXunitEntryPointDisableWarnings>false</EnableXunitEntryPointDisableWarnings>
+</PropertyGroup>
+````
+
 | Property | Default | Description |
 | --- | --- | --- |
 | `EnableDefaultTestFramework` | `true` | Adds `xunit.v3.mtp-v2` when no test framework is referenced, sets `OutputType` to `Exe` (required by xUnit.net v3) and `UseMicrosoftTestingPlatformRunner` to `true`. |
@@ -304,6 +320,7 @@ the missing `partial` modifier:
 | `EnableXunitFullParallelization` | Auto | Generates a source file with `[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.All)]` so every test runs in parallel, not just test collections. Generated when xUnit.net v3 4.0 or later is resolved, when set to `true` whatever the resolved references are, and never when set to `false`. |
 | `XunitParallelizationMode` | `All` | Sets the `Xunit.Sdk.ParallelMode` value used by the generated attribute: `None`, `Collections` or `All`. Setting it also generates the source file whatever the resolved references are. The file is not generated when `EnableXunitFullParallelization` is `false`. |
 | `EnableXunitStaticHelpers` | Auto | Generates the `Meziantou.NET.Sdk.Test.XUnitStaticHelpers` static class exposing `XunitCancellationToken` (`TestContext.Current.CancellationToken`). Generated when an xUnit.net v3 package is referenced, when set to `true` whatever the referenced packages are, and never when set to `false`. The global `using static` directive requires `ImplicitUsings`. |
+| `EnableXunitEntryPointDisableWarnings` | `true` | Defines the `XUNIT_ENTRYPOINT_DISABLE_WARNINGS` compilation constant. Set it to `false` to not define the constant. |
 | `EnableGitHubActionsReport` | `true` | Adds `Microsoft.Testing.Extensions.GitHubActionsReport` and `--report-gh --report-gh-slow-test-notices off`. The extension is inert unless the build runs on GitHub Actions. Slow-test notices are disabled as they are mostly noise on CI machines with varying performance. |
 | `EnableCodeCoverage` | `true` on CI | Enables code coverage collection on CI. |
 | `MinimumExpectedTests` | `1` | Sets `--minimum-expected-tests`, the number of tests that must run for the test run to succeed. Set it to `0` to not set the argument, as Microsoft.Testing.Platform only accepts a non-zero positive value. Note that the platform still expects at least one test to run when the argument is not set. |

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -226,6 +226,13 @@
     </ItemGroup>
   </Target>
 
+  <!-- Define the 'XUNIT_ENTRYPOINT_DISABLE_WARNINGS' compilation constant. Set 'EnableXunitEntryPointDisableWarnings' to 'false' to opt out. -->
+  <!-- Visual Basic separates the constants with ',' and requires a value for each of them, otherwise the compiler reports BC31030 -->
+  <PropertyGroup Condition="'$(EnableXunitEntryPointDisableWarnings)' != 'false'">
+    <DefineConstants Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(DefineConstants),XUNIT_ENTRYPOINT_DISABLE_WARNINGS=-1</DefineConstants>
+    <DefineConstants Condition="'$(MSBuildProjectExtension)' != '.vbproj'">$(DefineConstants);XUNIT_ENTRYPOINT_DISABLE_WARNINGS</DefineConstants>
+  </PropertyGroup>
+
   <!-- Add implicit using for xunit -->
   <ItemGroup Condition="'$(ImplicitUsings)' == 'enable' AND (
                             @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit')) == 'true' OR

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1844,6 +1844,59 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitStaticHelpers", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task MTP_XunitEntryPointDisableWarningsConstantIsDefined()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(filename: "Sample.Tests.csproj");
+
+        project.AddFile("Program.cs", """
+            #if !XUNIT_ENTRYPOINT_DISABLE_WARNINGS
+            #error XUNIT_ENTRYPOINT_DISABLE_WARNINGS is not defined
+            #endif
+
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+    }
+
+    [Fact]
+    public async Task MTP_XunitEntryPointDisableWarningsConstant_OptOut()
+    {
+        await using var project = CreateProjectBuilder(SdkTestName);
+        project.AddCsprojFile(
+            filename: "Sample.Tests.csproj",
+            properties: [("EnableXunitEntryPointDisableWarnings", "false")]
+            );
+
+        project.AddFile("Program.cs", """
+            #if XUNIT_ENTRYPOINT_DISABLE_WARNINGS
+            #error XUNIT_ENTRYPOINT_DISABLE_WARNINGS is defined
+            #endif
+
+            public class Tests
+            {
+                [Fact]
+                public void Test1()
+                {
+                }
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+    }
+
     // 'dotnet test' renders the results itself in MTP mode, so '--output Detailed' must be set on the command line.
     // The default arguments added by the SDK must not conflict with it.
     [Fact]


### PR DESCRIPTION
Test projects built with `Meziantou.NET.Sdk.Test` now define the `XUNIT_ENTRYPOINT_DISABLE_WARNINGS` compilation constant:

````csharp
#if XUNIT_ENTRYPOINT_DISABLE_WARNINGS
// ...
#endif
````

Set `EnableXunitEntryPointDisableWarnings` to `false` to not define it:

````xml
<PropertyGroup>
  <EnableXunitEntryPointDisableWarnings>false</EnableXunitEntryPointDisableWarnings>
</PropertyGroup>
````

## Changes

- `src/common/Tests.targets`: appends the constant to `DefineConstants` during evaluation, so no target is needed
- `README.md`: documents the constant and the `EnableXunitEntryPointDisableWarnings` property
- `tests/Meziantou.Sdk.Tests/SdkTests.cs`: two tests using `#if` + `#error`, so the build fails when the constant is not in the expected state

## Notes for the reviewer

- Visual Basic separates the constants with `,` and requires a value for each of them, so the constant is defined as `XUNIT_ENTRYPOINT_DISABLE_WARNINGS=-1` for `.vbproj` files. Both halves were verified with real builds: the `;`-separated form reports `error BC31030: Conditional compilation constant '; ^^ ^^ XUNIT_ENTRYPOINT_DISABLE_WARNINGS' is not valid`, and the `,NAME=-1` form builds clean, including when `DefineConstants` is empty. `$(MSBuildProjectExtension)` is used instead of `$(Language)` as the latter is not set yet when `Tests.targets` is imported.
- Nothing consumes the constant today: it appears neither in xUnit.net v3 4.0.0 (the entry point templates in `xunit.v3.msbuildtasks.dll` contain no `#if`/`#warning`) nor in `xunit.analyzers` 2.0.0, and a GitHub code search returns no hit. The documentation therefore only states what the constant is, not what it does.
- The property name mirrors the constant name; happy to rename it if another one reads better.

## Tests

`dotnet test tests/Meziantou.Sdk.Tests`: 354 passed, 0 failed.