### PR TITLE
Make the npm install stamp file specific to the current environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The SDK also blocks selected NuGet packages by default:
 | `EnableDefaultNpmPackageFile` | Enabled when unset | Enables automatic package.json inclusion as `NpmPackageFile` (set to `false` to disable). |
 | `NpmIgnoreScripts` | `true` | Adds `--ignore-scripts` to `npm install` / `npm ci` when `true` (set to `false` to allow lifecycle scripts). |
 | `NpmRestoreLockedMode` | `true` on CI or when `RestoreLockedMode` is `true` | Uses `npm ci` when `true`, otherwise `npm install`. |
+| `NpmStampFileIdentifier` | Current runtime identifier (e.g. `win-x64`, `linux-x64`) | Suffix of the `node_modules/.npm-install-stamp-*` file. It makes the stamp file specific to the current environment, so packages are reinstalled when the same folder is built from another OS or architecture (e.g. a Windows host and a dev container). |
 
 ## Testing
 

--- a/src/Meziantou.NET.Sdk.BlazorWebAssembly.nuspec
+++ b/src/Meziantou.NET.Sdk.BlazorWebAssembly.nuspec
@@ -20,9 +20,11 @@
     <file src="common/Tests.targets" target="common/Tests.targets" />
     <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" target="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.xunit.analyzers.editorconfig" target="configuration/Analyzer.xunit.analyzers.editorconfig" />
     <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
     <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
     <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />

--- a/src/Meziantou.NET.Sdk.Razor.nuspec
+++ b/src/Meziantou.NET.Sdk.Razor.nuspec
@@ -20,9 +20,11 @@
     <file src="common/Tests.targets" target="common/Tests.targets" />
     <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" target="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.xunit.analyzers.editorconfig" target="configuration/Analyzer.xunit.analyzers.editorconfig" />
     <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
     <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
     <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />

--- a/src/Meziantou.NET.Sdk.Test.nuspec
+++ b/src/Meziantou.NET.Sdk.Test.nuspec
@@ -20,9 +20,11 @@
     <file src="common/Tests.targets" target="common/Tests.targets" />
     <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" target="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.xunit.analyzers.editorconfig" target="configuration/Analyzer.xunit.analyzers.editorconfig" />
     <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
     <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
     <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />

--- a/src/Meziantou.NET.Sdk.Web.nuspec
+++ b/src/Meziantou.NET.Sdk.Web.nuspec
@@ -20,9 +20,11 @@
     <file src="common/Tests.targets" target="common/Tests.targets" />
     <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" target="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.xunit.analyzers.editorconfig" target="configuration/Analyzer.xunit.analyzers.editorconfig" />
     <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
     <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
     <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />

--- a/src/Meziantou.NET.Sdk.WindowsDesktop.nuspec
+++ b/src/Meziantou.NET.Sdk.WindowsDesktop.nuspec
@@ -20,9 +20,11 @@
     <file src="common/Tests.targets" target="common/Tests.targets" />
     <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" target="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.xunit.analyzers.editorconfig" target="configuration/Analyzer.xunit.analyzers.editorconfig" />
     <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
     <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
     <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />

--- a/src/Meziantou.NET.Sdk.nuspec
+++ b/src/Meziantou.NET.Sdk.nuspec
@@ -20,9 +20,11 @@
     <file src="common/Tests.targets" target="common/Tests.targets" />
     <file src="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" target="configuration/Analyzer.Devlooped.SponsorLink.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Analyzer.editorconfig" target="configuration/Analyzer.Meziantou.Analyzer.editorconfig" />
+    <file src="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" target="configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig" />
     <file src="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" target="configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig" />
     <file src="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" target="configuration/Analyzer.Microsoft.CodeAnalysis.NetAnalyzers.editorconfig" />
+    <file src="configuration/Analyzer.xunit.analyzers.editorconfig" target="configuration/Analyzer.xunit.analyzers.editorconfig" />
     <file src="configuration/BannedSymbols.NewtonsoftJson.txt" target="configuration/BannedSymbols.NewtonsoftJson.txt" />
     <file src="configuration/BannedSymbols.txt" target="configuration/BannedSymbols.txt" />
     <file src="configuration/CodingStyle.editorconfig" target="configuration/CodingStyle.editorconfig" />

--- a/src/common/Npm.targets
+++ b/src/common/Npm.targets
@@ -11,11 +11,19 @@
       <NpmRestoreLockedMode Condition="'$(NpmRestoreLockedMode)' == '' AND ('$(RestoreLockedMode)' == 'true' OR '$(ContinuousIntegrationBuild)' == 'true')">true</NpmRestoreLockedMode>
       <_NpmRestoreCommand Condition="'$(NpmRestoreLockedMode)' != 'true'">install</_NpmRestoreCommand>
       <_NpmRestoreCommand Condition="'$(NpmRestoreLockedMode)' == 'true'">ci</_NpmRestoreCommand>
+
+      <!-- The node_modules folder can be shared by multiple environments (e.g. a Windows host and a dev container using the same
+           folder). The installed packages are environment-specific, so the stamp file name contains an identifier of the current
+           environment to reinstall the packages when building from another environment. -->
+      <NpmStampFileIdentifier Condition="'$(NpmStampFileIdentifier)' == ''">$(NETCoreSdkPortableRuntimeIdentifier)</NpmStampFileIdentifier>
+      <NpmStampFileIdentifier Condition="'$(NpmStampFileIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</NpmStampFileIdentifier>
+      <NpmStampFileIdentifier Condition="'$(NpmStampFileIdentifier)' == ''">$(OS)-$([System.Runtime.InteropServices.RuntimeInformation]::get_OSArchitecture())</NpmStampFileIdentifier>
+      <_NpmStampFileName>.npm-install-stamp-$([System.Text.RegularExpressions.Regex]::Replace(`$(NpmStampFileIdentifier)`, '[^a-zA-Z0-9._-]', '_'))</_NpmStampFileName>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <NpmPackageFile>
-        <StampFile>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'node_modules', '.npm-install-stamp'))</StampFile>
+        <StampFile>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'node_modules', '$(_NpmStampFileName)'))</StampFile>
         <LockFile>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'package-lock.json'))</LockFile>
         <WorkingDirectory>%(RootDir)%(Directory)</WorkingDirectory>
         <_NpmInstallOptions>--no-fund --no-audit</_NpmInstallOptions>

--- a/src/configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Framework.Assertions.editorconfig
@@ -1,0 +1,112 @@
+# global_level must be higher than the NET Analyzer files
+is_global = true
+global_level = 0
+
+# MFAS0001: Pass the expected value before the actual value
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0001.severity = warning
+
+# MFAS0002: Use Assert.Same instead of Assert.ReferenceEquals
+# Enabled: True, Severity: error
+dotnet_diagnostic.MFAS0002.severity = error
+
+# MFAS0003: Do not use Assert.IsType with static or abstract types
+# Enabled: True, Severity: error
+dotnet_diagnostic.MFAS0003.severity = error
+
+# MFAS0004: Use Assert.Empty for zero count checks
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0004.severity = warning
+
+# MFAS0005: Use specialized count assertions
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0005.severity = warning
+
+# MFAS0006: Use Assert.Null for null comparisons
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0006.severity = warning
+
+# MFAS0007: Use Assert.NotNull for null comparisons
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0007.severity = warning
+
+# MFAS0008: Do not use Assert.Null with value types
+# Enabled: True, Severity: error
+dotnet_diagnostic.MFAS0008.severity = error
+
+# MFAS0009: Do not use Assert.NotNull with value types
+# Enabled: True, Severity: error
+dotnet_diagnostic.MFAS0009.severity = error
+
+# MFAS0010: Do not use Assert.Same with value types
+# Enabled: True, Severity: error
+dotnet_diagnostic.MFAS0010.severity = error
+
+# MFAS0011: Do not use Assert.NotSame with value types
+# Enabled: True, Severity: error
+dotnet_diagnostic.MFAS0011.severity = error
+
+# MFAS0012: Use Assert.IsAssignableTo for type pattern checks
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0012.severity = warning
+
+# MFAS0013: Use Assert.IsNotAssignableTo for type pattern checks
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0013.severity = warning
+
+# MFAS0014: Use Assert.Matches instead of Assert.True(Regex.IsMatch(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0014.severity = warning
+
+# MFAS0015: Use Assert.DoesNotMatch instead of Assert.False(Regex.IsMatch(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0015.severity = warning
+
+# MFAS0016: Use Assert.Contains instead of Assert.True(string.Contains(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0016.severity = warning
+
+# MFAS0017: Use Assert.DoesNotContain instead of Assert.False(string.Contains(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0017.severity = warning
+
+# MFAS0018: Use Assert.StartsWith instead of Assert.True(string.StartsWith(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0018.severity = warning
+
+# MFAS0019: Use Assert.DoesNotStartWith instead of Assert.False(string.StartsWith(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0019.severity = warning
+
+# MFAS0020: Use Assert.EndsWith instead of Assert.True(string.EndsWith(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0020.severity = warning
+
+# MFAS0021: Use Assert.DoesNotEndWith instead of Assert.False(string.EndsWith(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0021.severity = warning
+
+# MFAS0022: Use Assert.Contains instead of Assert.True(collection.Contains(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0022.severity = warning
+
+# MFAS0023: Use Assert.DoesNotContain instead of Assert.False(collection.Contains(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0023.severity = warning
+
+# MFAS0024: Use Assert.Contains instead of Assert.True(collection.Any(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0024.severity = warning
+
+# MFAS0025: Use Assert.DoesNotContain instead of Assert.False(collection.Any(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0025.severity = warning
+
+# MFAS0026: Use Assert.All instead of Assert.True(collection.All(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0026.severity = warning
+
+# MFAS0027: Use Assert.DoesNotAll instead of Assert.False(collection.All(...))
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFAS0027.severity = warning
+

--- a/src/configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Framework.FullPath.editorconfig
@@ -14,7 +14,7 @@ dotnet_diagnostic.MFFP0002.severity = warning
 # Enabled: True, Severity: suggestion
 dotnet_diagnostic.MFFP0003.severity = warning
 
-# MFFP0004: Use '/' operator instead of Path.Combine
+# MFFP0004: Use '/' operator instead of Path.Combine or Path.Join
 # Enabled: True, Severity: suggestion
 dotnet_diagnostic.MFFP0004.severity = warning
 
@@ -45,4 +45,52 @@ dotnet_diagnostic.MFFP0010.severity = warning
 # MFFP0011: Return FullPath instead of string
 # Enabled: True, Severity: suggestion
 dotnet_diagnostic.MFFP0011.severity = warning
+
+# MFFP0012: Declare the property as FullPath instead of string
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0012.severity = suggestion
+
+# MFFP0013: Declare the variable as FullPath instead of string
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0013.severity = suggestion
+
+# MFFP0014: Declare the parameter as FullPath instead of string
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0014.severity = suggestion
+
+# MFFP0015: Compare FullPath values instead of their string representation
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFFP0015.severity = warning
+
+# MFFP0016: FullPath.Equals with a string argument is always false
+# Enabled: True, Severity: warning
+dotnet_diagnostic.MFFP0016.severity = warning
+
+# MFFP0018: Path.IsPathRooted and Path.IsPathFullyQualified are redundant on a FullPath
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0018.severity = suggestion
+
+# MFFP0019: Simplify the FullPath.FromPath call
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0019.severity = suggestion
+
+# MFFP0020: Use FullPath.FromFileSystemInfo instead of FullPath.FromPath
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0020.severity = suggestion
+
+# MFFP0021: Use FullPath.IsEmpty
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0021.severity = suggestion
+
+# MFFP0022: Use FullPath.CreateParentDirectory instead of Directory.CreateDirectory
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0022.severity = suggestion
+
+# MFFP0023: Use FullPath.Parent instead of Directory.GetParent
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0023.severity = suggestion
+
+# MFFP0024: Use the FullPath equivalent of Path.GetTempPath or Environment.GetFolderPath
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.MFFP0024.severity = suggestion
 

--- a/src/configuration/Analyzer.xunit.analyzers.editorconfig
+++ b/src/configuration/Analyzer.xunit.analyzers.editorconfig
@@ -1,0 +1,559 @@
+# global_level must be higher than the NET Analyzer files
+is_global = true
+global_level = 0
+
+# xUnit1000: Test classes must be public
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1000
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1000.severity = error
+
+# xUnit1001: Fact methods cannot have parameters
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1001
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1001.severity = error
+
+# xUnit1002: Test methods cannot have multiple Fact or Theory attributes
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1002
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1002.severity = error
+
+# xUnit1003: Theory methods must have test data
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1003
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1003.severity = error
+
+# xUnit1004: Test methods should not be skipped
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1004
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1004.severity = suggestion
+
+# xUnit1005: Fact methods should not have test data
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1005
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1005.severity = warning
+
+# xUnit1006: Theory methods should have parameters
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1006
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1006.severity = warning
+
+# xUnit1007: ClassData must point at a valid class
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1007
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1007.severity = error
+
+# xUnit1008: Test data attribute should only be used on a Theory
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1008
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1008.severity = warning
+
+# xUnit1009: InlineData values must match the number of method parameters
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1009
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1009.severity = error
+
+# xUnit1010: The value is not convertible to the method parameter type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1010
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1010.severity = error
+
+# xUnit1011: There is no matching method parameter
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1011
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1011.severity = error
+
+# xUnit1012: Null should only be used for nullable parameters
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1012
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1012.severity = warning
+
+# xUnit1013: Public method should be marked as test
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1013
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1013.severity = warning
+
+# xUnit1014: MemberData should use nameof operator for member name
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1014
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1014.severity = warning
+
+# xUnit1015: MemberData must reference an existing member
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1015
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1015.severity = error
+
+# xUnit1016: MemberData must reference a public member
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1016
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1016.severity = error
+
+# xUnit1017: MemberData must reference a static member
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1017
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1017.severity = error
+
+# xUnit1018: MemberData must reference a valid member kind
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1018
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1018.severity = error
+
+# xUnit1019: MemberData must reference a member providing a valid data type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1019
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1019.severity = error
+
+# xUnit1020: MemberData must reference a property with a public getter
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1020
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1020.severity = error
+
+# xUnit1021: MemberData should not have parameters if the referenced member is not a method
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1021
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1021.severity = warning
+
+# xUnit1022: Theory methods cannot have a parameter array
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1022
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1022.severity = error
+
+# xUnit1023: Theory methods cannot have default parameter values
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1023
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1023.severity = error
+
+# xUnit1024: Test methods cannot have overloads
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1024
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1024.severity = error
+
+# xUnit1025: InlineData should be unique within the Theory it belongs to
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1025
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1025.severity = warning
+
+# xUnit1026: Theory methods should use all of their parameters
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1026
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1026.severity = warning
+
+# xUnit1027: Collection definition classes must be public
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1027
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1027.severity = error
+
+# xUnit1028: Test method must have valid return type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1028
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1028.severity = error
+
+# xUnit1029: Local functions cannot be test functions
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1029
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1029.severity = error
+
+# xUnit1030: Do not call ConfigureAwait(false) in test method
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1030
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1030.severity = warning
+
+# xUnit1031: Do not use blocking task operations in test method
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1031
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1031.severity = warning
+
+# xUnit1032: Test classes cannot be nested within a generic class
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1032
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1032.severity = error
+
+# xUnit1033: Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1033
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1033.severity = suggestion
+
+# xUnit1034: Null should only be used for nullable parameters
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1034
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1034.severity = warning
+
+# xUnit1035: The value is not convertible to the method parameter type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1035
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1035.severity = error
+
+# xUnit1036: There is no matching method parameter
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1036
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1036.severity = error
+
+# xUnit1037: There are fewer theory data type arguments than required by the parameters of the test method
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1037
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1037.severity = error
+
+# xUnit1038: There are more theory data type arguments than allowed by the parameters of the test method
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1038
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1038.severity = error
+
+# xUnit1039: The type argument to theory data is not compatible with the type of the corresponding test method parameter
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1039
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1039.severity = error
+
+# xUnit1040: The type argument to theory data is nullable, while the type of the corresponding test method parameter is not
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1040
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1040.severity = warning
+
+# xUnit1041: Fixture arguments to test classes must have fixture sources
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1041
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1041.severity = warning
+
+# xUnit1042: The member referenced by the MemberData attribute returns untyped data rows
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1042
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1042.severity = suggestion
+
+# xUnit1043: Constructors on classes derived from FactAttribute must be public when used on test methods
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1043
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1043.severity = error
+
+# xUnit1044: Avoid using TheoryData type arguments that are not serializable
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1044
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1044.severity = suggestion
+
+# xUnit1045: Avoid using TheoryData type arguments that might not be serializable
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1045
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1045.severity = suggestion
+
+# xUnit1046: Avoid using TheoryDataRow arguments that are not serializable
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1046
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1046.severity = suggestion
+
+# xUnit1047: Avoid using TheoryDataRow arguments that might not be serializable
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1047
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1047.severity = suggestion
+
+# xUnit1048: Avoid using 'async void' for test methods as it is deprecated in xUnit.net v3
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1048
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1048.severity = warning
+
+# xUnit1049: Do not use 'async void' for test methods as it is no longer supported
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1049
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1049.severity = error
+
+# xUnit1050: The class referenced by the ClassData attribute returns untyped data rows
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1050
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit1050.severity = suggestion
+
+# xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1051
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1051.severity = warning
+
+# xUnit1052: Avoid using 'TheoryData<...>' with types that implement 'ITheoryDataRow'.
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1052
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1052.severity = warning
+
+# xUnit1053: The static member used as theory data must be statically initialized.
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1053
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1053.severity = warning
+
+# xUnit1054: Properties used for conditional skipping must be public, static, and return bool
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1054
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1054.severity = error
+
+# xUnit1055: Conditional skipping cannot set both SkipUnless and SkipWhen
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1055
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1055.severity = error
+
+# xUnit1056: Type must have a single public non-static constructor
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1056
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1056.severity = error
+
+# xUnit1057: Type must be public or internal
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1057
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1057.severity = error
+
+# xUnit1058: Generic collection definitions are not supported in Native AOT
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1058
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1058.severity = error
+
+# xUnit1059: Test classes may not be decorated with ICollectionFixture<>
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1059
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1059.severity = warning
+
+# xUnit1060: Cultured test methods must have at least one culture
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1060
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1060.severity = error
+
+# xUnit1061: Fact methods cannot be generic
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1061
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1061.severity = error
+
+# xUnit1062: Theory methods cannot be generic in Native AOT
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1062
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1062.severity = error
+
+# xUnit1063: Test classes cannot be an open generic type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1063
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1063.severity = error
+
+# xUnit1064: Theory parameter cannot use params modifier in Native AOT
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1064
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1064.severity = error
+
+# xUnit1065: MemberData method is ambiguous
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1065
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1065.severity = error
+
+# xUnit1066: MemberData parameter cannot use params modifier in Native AOT
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1066
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1066.severity = error
+
+# xUnit1067: There is no matching MemberData method argument
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1067
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1067.severity = error
+
+# xUnit1068: MemberData cannot point to an open generic type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1068
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit1068.severity = error
+
+# xUnit1069: Test methods with a Timeout should reference TestContext.Current.CancellationToken
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit1069
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit1069.severity = warning
+
+# xUnit2000: Constants and literals should be the expected argument
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2000
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2000.severity = warning
+
+# xUnit2001: Do not use invalid equality check
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2001
+# Enabled: True, Severity: silent
+dotnet_diagnostic.xUnit2001.severity = silent
+
+# xUnit2002: Do not use null check on value type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2002
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2002.severity = warning
+
+# xUnit2003: Do not use equality check to test for null value
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2003
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2003.severity = warning
+
+# xUnit2004: Do not use equality check to test for boolean conditions
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2004
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2004.severity = warning
+
+# xUnit2005: Do not use identity check on value type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2005
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2005.severity = warning
+
+# xUnit2006: Do not use invalid string equality check
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2006
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2006.severity = warning
+
+# xUnit2007: Do not use typeof expression to check the type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2007
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2007.severity = warning
+
+# xUnit2008: Do not use boolean check to match on regular expressions
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2008
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2008.severity = warning
+
+# xUnit2009: Do not use boolean check to check for substrings
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2009
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2009.severity = warning
+
+# xUnit2010: Do not use boolean check to check for string equality
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2010
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2010.severity = warning
+
+# xUnit2011: Do not use empty collection check
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2011
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2011.severity = warning
+
+# xUnit2012: Do not use boolean check to check if a value exists in a collection
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2012
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2012.severity = warning
+
+# xUnit2013: Do not use equality check to check for collection size.
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2013
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2013.severity = warning
+
+# xUnit2014: Do not use throws check to check for asynchronously thrown exception
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2014
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit2014.severity = error
+
+# xUnit2015: Do not use typeof expression to check the exception type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2015
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2015.severity = warning
+
+# xUnit2016: Keep precision in the allowed range when asserting equality of doubles or decimals.
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2016
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit2016.severity = error
+
+# xUnit2017: Do not use Contains() to check if a value exists in a collection
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2017
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2017.severity = warning
+
+# xUnit2018: Do not compare an object's exact type to an abstract class or interface
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2018
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2018.severity = warning
+
+# xUnit2020: Do not use always-failing boolean assertions
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2020
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2020.severity = warning
+
+# xUnit2021: Async assertions should be awaited
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2021
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit2021.severity = error
+
+# xUnit2022: Boolean assertions should not be negated
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2022
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit2022.severity = suggestion
+
+# xUnit2023: Do not use collection methods for single-item collections
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2023
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit2023.severity = suggestion
+
+# xUnit2024: Do not use boolean asserts for simple equality tests
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2024
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit2024.severity = suggestion
+
+# xUnit2025: The boolean assertion statement can be simplified
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2025
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit2025.severity = suggestion
+
+# xUnit2026: Comparison of sets must be done with IEqualityComparer
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2026
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2026.severity = warning
+
+# xUnit2027: Comparison of sets to linear containers have undefined results
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2027
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2027.severity = warning
+
+# xUnit2028: Do not use Assert.Empty or Assert.NotEmpty with problematic types
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2028
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2028.severity = warning
+
+# xUnit2029: Do not use Assert.Empty to check if a value does not exist in a collection
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2029
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2029.severity = warning
+
+# xUnit2030: Do not use Assert.NotEmpty to check if a value exists in a collection
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2030
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2030.severity = warning
+
+# xUnit2031: Do not use Where clause with Assert.Single
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2031
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit2031.severity = warning
+
+# xUnit2032: Type assertions based on 'assignable from' are confusingly named
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2032
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit2032.severity = suggestion
+
+# xUnit2033: Use the assertion return value instead of re-deriving it
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit2033
+# Enabled: True, Severity: suggestion
+dotnet_diagnostic.xUnit2033.severity = suggestion
+
+# xUnit3000: Classes which cross AppDomain boundaries must derive directly or indirectly from LongLivedMarshalByRefObject
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3000
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit3000.severity = error
+
+# xUnit3001: Classes that are marked as serializable (or created by the test framework at runtime) must have a public parameterless constructor
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3001
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit3001.severity = error
+
+# xUnit3002: Classes which are JSON serializable should not be tested for their concrete type
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3002
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit3002.severity = warning
+
+# xUnit3003: Classes which extend FactAttribute (directly or indirectly) should provide a public constructor for source information
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3003
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit3003.severity = warning
+
+# xUnit3004: The given type is missing a required interface implementation
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3004
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit3004.severity = error
+
+# xUnit3005: Type must have an appropriate non-obsolete public constructor
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3005
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit3005.severity = error
+
+# xUnit3006: Test case implementation must be serializable
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3006
+# Enabled: True, Severity: error
+dotnet_diagnostic.xUnit3006.severity = error
+
+# xUnit3007: Test case implementation might not be serializable
+# Help link: https://xunit.net/xunit.analyzers/rules/xUnit3007
+# Enabled: True, Severity: warning
+dotnet_diagnostic.xUnit3007.severity = warning
+

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -2447,6 +2447,26 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.Fail("Attribute not found");
     }
 
+    private static string[] GetNpmStampFiles(FullPath projectFolder)
+    {
+        var nodeModules = projectFolder / "node_modules";
+        return Directory.Exists(nodeModules) ? Directory.GetFiles(nodeModules, ".npm-install-stamp-*") : [];
+    }
+
+    private static void AssertNpmStampFileExists(FullPath projectFolder)
+    {
+        // The stamp file is environment-specific, so the same node_modules folder can be used from multiple environments
+        // (e.g. a Windows host and a dev container) without skipping the npm restore
+        var expectedPrefix = ".npm-install-stamp-" + (OperatingSystem.IsWindows() ? "win" : OperatingSystem.IsMacOS() ? "osx" : "linux");
+        var stampFile = Assert.Single(GetNpmStampFiles(projectFolder));
+        Assert.StartsWith(expectedPrefix, Path.GetFileName(stampFile), StringComparison.Ordinal);
+    }
+
+    private static void AssertNpmStampFileDoesNotExist(FullPath projectFolder)
+    {
+        Assert.Empty(GetNpmStampFiles(projectFolder));
+    }
+
     [Fact]
     public async Task NpmInstall()
     {
@@ -2468,7 +2488,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.BuildAndGetOutput();
         Assert.Equal(0, data.ExitCode);
         Assert.True(File.Exists(project.RootFolder / "package-lock.json"));
-        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileExists(project.RootFolder);
         var files = data.GetBinLogFiles();
         Assert.Contains(files, f => f.EndsWith("package-lock.json", StringComparison.Ordinal));
     }
@@ -2541,7 +2561,42 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.RestoreAndGetOutput();
         Assert.Equal(0, data.ExitCode);
         Assert.True(File.Exists(project.RootFolder / "package-lock.json"));
-        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileExists(project.RootFolder);
+    }
+
+    [Fact]
+    public async Task NpmRestore_StampFileIsEnvironmentSpecific()
+    {
+        await using var project = CreateProjectBuilder(SdkWebName);
+        project.AddCsprojFile();
+
+        project.AddFile("Program.cs", "Console.WriteLine();");
+        project.AddFile("package.json", """
+            {
+              "name": "sample",
+              "version": "1.0.0",
+              "private": true,
+              "devDependencies": {
+                "is-number": "7.0.0"
+              }
+            }
+            """);
+
+        var data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env1"]);
+        Assert.Equal(0, data.ExitCode);
+        Assert.True(data.IsMSBuildTargetExecuted("NpmRestore"));
+        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp-env1"));
+
+        // The packages must be installed again when building the same folder from another environment
+        data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env2"]);
+        Assert.Equal(0, data.ExitCode);
+        Assert.True(data.IsMSBuildTargetExecuted("NpmRestore"));
+        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp-env2"));
+
+        // The packages must not be installed again when building from an environment that is already up to date
+        data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env1"]);
+        Assert.Equal(0, data.ExitCode);
+        Assert.False(data.IsMSBuildTargetExecuted("NpmRestore"));
     }
 
     [Fact]
@@ -2565,7 +2620,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.RestoreAndGetOutput();
         Assert.Equal(0, data.ExitCode);
         Assert.False(File.Exists(project.RootFolder / "package-lock.json"));
-        Assert.False(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileDoesNotExist(project.RootFolder);
     }
 
     [Fact]
@@ -2594,7 +2649,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.BuildAndGetOutput([slnFile]);
         Assert.Equal(0, data.ExitCode);
         Assert.True(File.Exists(project.RootFolder / "package-lock.json"));
-        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileExists(project.RootFolder);
     }
 
     [Theory]
@@ -2653,7 +2708,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.Equal(0, data.ExitCode);
 
         Assert.True(File.Exists(project.RootFolder / "package-lock.json"));
-        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileExists(project.RootFolder);
     }
 
     [Fact]
@@ -2692,9 +2747,9 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.RestoreAndGetOutput();
         Assert.Equal(0, data.ExitCode);
         Assert.True(File.Exists(project.RootFolder / "a" / "package-lock.json"));
-        Assert.True(File.Exists(project.RootFolder / "a" / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileExists(project.RootFolder / "a");
         Assert.True(File.Exists(project.RootFolder / "b" / "package-lock.json"));
-        Assert.True(File.Exists(project.RootFolder / "b" / "node_modules" / ".npm-install-stamp"));
+        AssertNpmStampFileExists(project.RootFolder / "b");
     }
 
     [Fact]


### PR DESCRIPTION
## What

`Npm.targets` writes `node_modules/.npm-install-stamp` after running `npm install` / `npm ci`, and uses it as the `Outputs` of the `NpmRestore` target to skip the install when it is up to date.

The stamp file name is now suffixed with an identifier of the current environment: `node_modules/.npm-install-stamp-<identifier>`. The identifier defaults to the current runtime identifier (`win-x64`, `linux-x64`, `osx-arm64`, …), with fallbacks to `NETCoreSdkRuntimeIdentifier` and to `$(OS)-<OSArchitecture>`, and is sanitized (`[^a-zA-Z0-9._-]` → `_`) so a custom value cannot produce an invalid file name.

The new `NpmStampFileIdentifier` property allows overriding it to include anything else that is relevant for a repository (node version, container image tag, …). It is documented in the `npm restore` table of the README.

## Why

The `node_modules` folder can be shared by multiple environments — restore the packages on a Windows host, then open the same folder in a dev container and build again. With a single global stamp file, the packages were considered up to date and were not reinstalled, even though the content of `node_modules` is platform-specific (native binaries, optional per-platform dependencies).

## Notes for reviewers

- Leftover `.npm-install-stamp` files written by a previous version of the SDK are ignored: the new stamp is missing, so the packages are installed once and the new stamp is created.
- `NETCoreSdkPortableRuntimeIdentifier` comes from the .NET SDK props, so it is also available when building with the .NET Framework based MSBuild.
- Unrelated and unchanged: `package-lock.json` is still not part of the `NpmRestore` target `Inputs`, so a lock-file-only change does not trigger a reinstall.

## Tests

- The existing assertions moved to `AssertNpmStampFileExists` / `AssertNpmStampFileDoesNotExist`, which also check that the stamp file name starts with the expected OS prefix (`win`, `osx` or `linux`).
- New `NpmRestore_StampFileIsEnvironmentSpecific` test: restores with `NpmStampFileIdentifier=env1`, then `env2` — asserting from the binlog that the `NpmRestore` target actually ran again instead of being skipped — then `env1` again to check it is skipped as up to date. This test fails without the fix.
- All 20 npm tests pass locally (10 per SDK version, .NET 10 and .NET 11): `dotnet run --project tests/Meziantou.Sdk.Tests/Meziantou.Sdk.Tests.csproj -- --filter-method "*.Npm*"`

---

## Second commit: regenerate the analyzer configuration files

Unrelated to the npm change, but `lint_config` was already failing on `main` and blocks this PR. Running `ConfigFilesGenerator` produces three changes:

- `Analyzer.Meziantou.Framework.FullPath.editorconfig` — the package published new rules (MFFP0012 to MFFP0024)
- `Analyzer.Meziantou.Framework.Assertions.editorconfig` (new) — the package is referenced since 8cf1b42, but its configuration file had never been generated
- `Analyzer.xunit.analyzers.editorconfig` (new) — transitive from `xunit.v3`

The two new files are added to the six `.nuspec` files so they ship with the SDKs like the other analyzer configuration files. The generator preserves the severities that were already configured and only writes the analyzer default for rules it does not know yet, so the `FullPath` rules that were escalated to `warning` keep their severity.

The full test suite (352 tests) passes locally with the packages built from these nuspec files.
