### PR TITLE
Remove the stamp files of the other environments after an npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The SDK also blocks selected NuGet packages by default:
 | `EnableDefaultNpmPackageFile` | Enabled when unset | Enables automatic package.json inclusion as `NpmPackageFile` (set to `false` to disable). |
 | `NpmIgnoreScripts` | `true` | Adds `--ignore-scripts` to `npm install` / `npm ci` when `true` (set to `false` to allow lifecycle scripts). |
 | `NpmRestoreLockedMode` | `true` on CI or when `RestoreLockedMode` is `true` | Uses `npm ci` when `true`, otherwise `npm install`. |
-| `NpmStampFileIdentifier` | Current runtime identifier (e.g. `win-x64`, `linux-x64`) | Suffix of the `node_modules/.npm-install-stamp-*` file. It makes the stamp file specific to the current environment, so packages are reinstalled when the same folder is built from another OS or architecture (e.g. a Windows host and a dev container). |
+| `NpmStampFileIdentifier` | Current runtime identifier (e.g. `win-x64`, `linux-x64`) | Suffix of the `node_modules/.npm-install-stamp-*` file. It makes the stamp file specific to the current environment, so packages are reinstalled when the same folder is built from another OS or architecture (e.g. a Windows host and a dev container). Installing the packages removes the stamp files of the other environments, as their packages are replaced by the newly installed ones. |
 
 ## Testing
 

--- a/src/common/Npm.targets
+++ b/src/common/Npm.targets
@@ -23,6 +23,7 @@
 
     <ItemGroup>
       <NpmPackageFile>
+        <NodeModulesFolder>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'node_modules'))</NodeModulesFolder>
         <StampFile>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'node_modules', '$(_NpmStampFileName)'))</StampFile>
         <LockFile>$([System.IO.Path]::Combine(`%(RootDir)%(Directory)`, 'package-lock.json'))</LockFile>
         <WorkingDirectory>%(RootDir)%(Directory)</WorkingDirectory>
@@ -39,6 +40,20 @@
   <Target Name="NpmRestore" DependsOnTargets="ComputeNpmPackageMetadata;NpmRestoreForce" Inputs="@(NpmPackageFile)" Outputs="%(NpmPackageFile.StampFile)" BeforeTargets="Restore;CollectPackageReferences">
     <Message Importance="high" Text="Installing npm packages for @(NpmPackageFile)" />
     <Exec Command="@(NpmPackageFile->'%(RestoreCommand)')" WorkingDirectory="%(WorkingDirectory)" />
+
+    <!-- The packages installed for the current environment replace the packages installed for any other environment,
+         so the stamp files of the other environments are stale and must not be used to skip the installation.
+         The search pattern must come from a property as wildcards are not expanded when they come from item metadata. -->
+    <PropertyGroup>
+      <_NpmStampFileSearchPattern>%(NpmPackageFile.NodeModulesFolder)/.npm-install-stamp-*</_NpmStampFileSearchPattern>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_NpmStampFileToDelete Remove="@(_NpmStampFileToDelete)" />
+      <_NpmStampFileToDelete Include="$(_NpmStampFileSearchPattern)" />
+    </ItemGroup>
+
+    <Delete Files="@(_NpmStampFileToDelete)" />
     <Touch Files="@(NpmPackageFile->'%(StampFile)')" AlwaysCreate="true" />
   </Target>
 

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -2453,6 +2453,11 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         return Directory.Exists(nodeModules) ? Directory.GetFiles(nodeModules, ".npm-install-stamp-*") : [];
     }
 
+    private static string GetSingleNpmStampFileName(FullPath projectFolder)
+    {
+        return Path.GetFileName(Assert.Single(GetNpmStampFiles(projectFolder)));
+    }
+
     private static void AssertNpmStampFileExists(FullPath projectFolder)
     {
         // The stamp file is environment-specific, so the same node_modules folder can be used from multiple environments
@@ -2585,18 +2590,27 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env1"]);
         Assert.Equal(0, data.ExitCode);
         Assert.True(data.IsMSBuildTargetExecuted("NpmRestore"));
-        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp-env1"));
+        Assert.Equal(".npm-install-stamp-env1", GetSingleNpmStampFileName(project.RootFolder));
 
-        // The packages must be installed again when building the same folder from another environment
-        data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env2"]);
-        Assert.Equal(0, data.ExitCode);
-        Assert.True(data.IsMSBuildTargetExecuted("NpmRestore"));
-        Assert.True(File.Exists(project.RootFolder / "node_modules" / ".npm-install-stamp-env2"));
-
-        // The packages must not be installed again when building from an environment that is already up to date
+        // The packages must not be installed again when restoring from the same environment
         data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env1"]);
         Assert.Equal(0, data.ExitCode);
         Assert.False(data.IsMSBuildTargetExecuted("NpmRestore"));
+        Assert.Equal(".npm-install-stamp-env1", GetSingleNpmStampFileName(project.RootFolder));
+
+        // The packages must be installed again when restoring the same folder from another environment.
+        // The stamp file of the first environment must be removed as its packages are replaced by the new ones.
+        data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env2"]);
+        Assert.Equal(0, data.ExitCode);
+        Assert.True(data.IsMSBuildTargetExecuted("NpmRestore"));
+        Assert.Equal(".npm-install-stamp-env2", GetSingleNpmStampFileName(project.RootFolder));
+
+        // The packages of the first environment were replaced by the packages of the second environment,
+        // so they must be installed again when restoring from the first environment
+        data = await project.RestoreAndGetOutput(["/p:NpmStampFileIdentifier=env1"]);
+        Assert.Equal(0, data.ExitCode);
+        Assert.True(data.IsMSBuildTargetExecuted("NpmRestore"));
+        Assert.Equal(".npm-install-stamp-env1", GetSingleNpmStampFileName(project.RootFolder));
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #206.

## Problem

The stamp file used to skip `npm install` is environment-specific, but the stamp files of the other environments were never invalidated. The `node_modules` folder holds a single set of packages, so installing from one environment replaces the packages installed by another one, while the other environment's stamp file still claims the folder is up to date:

- Restore on Windows => install the packages, create `.npm-install-stamp-win-x64`
- Restore in a Linux dev container => replace the packages, create `.npm-install-stamp-linux-x64`
- Restore on Windows => **skipped**, although the installed packages are the Linux ones

## Change

`NpmRestore` now deletes every `.npm-install-stamp-*` file of the `node_modules` folder after installing the packages, before creating the stamp file of the current environment. Only the environment that installed the packages last has a stamp file, so any other environment reinstalls them.

## Notes for the reviewer

- The search pattern goes through a property (`_NpmStampFileSearchPattern`) because MSBuild does not expand wildcards coming from item metadata (`Include="%(Item.Metadata)"` keeps the `*` as a literal, so `Delete` silently deletes nothing).
- The `Remove` before the `Include` prevents a batch from inheriting the matches of the previous batch when a project has several `package.json` files.
- `NpmRestore_StampFileIsEnvironmentSpecific` now asserts the packages are installed again when going back to the first environment (the test previously asserted the opposite), and that a single stamp file exists at each step.
- Not changed: `dotnet msbuild /t:NpmInstall` still runs `npm install` without touching any stamp file, so it can leave another environment's stamp file valid over the newly installed packages.

## Test

`dotnet test tests/Meziantou.Sdk.Tests --filter "FullyQualifiedName~Npm"` => 20/20 pass.