### PR TITLE
Remove SBOM generation from the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,8 @@ Set these properties in your project file or a directory-level props file. Unles
 
 | Property | Default | Description |
 | --- | --- | --- |
-| `ContinuousIntegrationBuild` | Auto-detected | Set to `true` or `false` to force CI behavior (warnings as errors, code style enforcement, SBOM, code coverage, npm locked mode). |
+| `ContinuousIntegrationBuild` | Auto-detected | Set to `true` or `false` to force CI behavior (warnings as errors, code style enforcement, code coverage, npm locked mode). |
 | `TargetFramework` | `net$(NETCoreAppMaximumVersion)` | Used when both `TargetFramework` and `TargetFrameworks` are empty. |
-| `GenerateSBOM` | `true` on CI | Controls SBOM generation on CI builds. |
 | `RollForward` | `LatestMajor` | Applied for non-test projects when unset. |
 | `SuppressNETCoreSdkPreviewMessage` | `true` | Suppresses preview SDK message. |
 | `PublishRepositoryUrl` | `true` | Publishes repository URL in packages. |

--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -88,11 +88,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" IsImplicitlyDefined="true">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.159" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -9,10 +9,6 @@
 	<Import Project="$(MSBuildThisFileDirectory)/Npm.targets" />
 
 	<PropertyGroup>
-    <GenerateSBOM Condition="'$(GenerateSBOM)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">true</GenerateSBOM>
-	</PropertyGroup>
-
-	<PropertyGroup>
 		<!-- Suppress documentation warnings (CS1573, CS1591) unless DisableDocumentationWarnings is set to false -->
 		<NoWarn Condition="'$(DisableDocumentationWarnings)' != 'false'">$(NoWarn);CS1573;CS1591</NoWarn>
 	</PropertyGroup>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -101,33 +101,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task GenerateSbom_IsSetWhenContinuousIntegrationBuildIsSet()
-    {
-        await using var project = CreateProjectBuilder();
-        project.AddCsprojFile(properties: [("ContinuousIntegrationBuild", "true")]);
-        project.AddFile("Program.cs", "Console.WriteLine();");
-        var data = await project.PackAndGetOutput();
-        data.AssertMSBuildPropertyValue("GenerateSBOM", "true");
-
-        var nupkg = Directory.GetFiles(project.RootFolder, "*.nupkg", SearchOption.AllDirectories).Single();
-        using var archive = ZipFile.OpenRead(nupkg);
-        Assert.Contains(archive.Entries, e => e.FullName.EndsWith("manifest.spdx.json", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task GenerateSbom_IsNotSetWhenContinuousIntegrationBuildIsNotSet()
-    {
-        await using var project = CreateProjectBuilder();
-        project.AddCsprojFile();
-        project.AddFile("Program.cs", "Console.WriteLine();");
-        var data = await project.PackAndGetOutput();
-
-        var nupkg = Directory.GetFiles(project.RootFolder, "*.nupkg", SearchOption.AllDirectories).Single();
-        using var archive = ZipFile.OpenRead(nupkg);
-        Assert.DoesNotContain(archive.Entries, e => e.FullName.EndsWith("manifest.spdx.json", StringComparison.Ordinal));
-    }
-
-    [Fact]
     public async Task CanOverrideRollForward()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
Removes SBOM support from the SDK.

## Changes

- `src/common/Common.props`: dropped the implicit `Microsoft.Sbom.Targets` 4.1.5 `PackageReference`.
- `src/common/Common.targets`: removed the `PropertyGroup` that defaulted `GenerateSBOM` to `true` on CI builds.
- `tests/Meziantou.Sdk.Tests/SdkTests.cs`: deleted the two `GenerateSbom_*` tests asserting `manifest.spdx.json` presence/absence in the packed nupkg.
- `README.md`: removed the `GenerateSBOM` row and dropped "SBOM" from the `ContinuousIntegrationBuild` description.

No `sbom`/`spdx` references remain in the repository.

## Behavior change

Packages built on CI no longer contain an SPDX manifest. Setting `GenerateSBOM` explicitly is now inert, since the targets package that consumed it is gone.

## Validation

- `dotnet build Meziantou.NET.Sdk.slnx` — succeeded, 0 warnings.
- Full test suite: 348 passed, 0 failed.