### PR TITLE
Add Meziantou.Analyzer.Annotations package reference

### DIFF
--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -93,6 +93,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
+    <PackageReference Include="Meziantou.Analyzer.Annotations" Version="1.8.0" Condition="$(PackageId) != 'Meziantou.Analyzer' AND $(PackageId) != 'Meziantou.Analyzer.Annotations'" IsImplicitlyDefined="true">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -246,7 +246,9 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         }
 
         Assert.Contains(files, f => f.EndsWith(".editorconfig", StringComparison.Ordinal));
-        Assert.Contains(files, f => f == localFile || f == "/private" + localFile); // macos may prefix it with /private
+        // macos may prefix the path with /private
+        Assert.Contains(files, f => FullPathComparer.Default.Equals(FullPath.FromPath(f), localFile)
+                                 || FullPathComparer.Default.Equals(FullPath.FromPath(f), FullPath.FromPath("/private" + localFile)));
     }
 
     [Fact]

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1023,6 +1023,33 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task MeziantouAnalyzerAnnotationsCsproj()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(filename: "Meziantou.Analyzer.Annotations.csproj");
+        project.AddFile("Program.cs", """Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+        Assert.Equal(0, data.ExitCode);
+    }
+
+    [Fact]
+    public async Task MeziantouAnalyzerAnnotationsAreReferenced()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Program.cs", """Console.WriteLine();""");
+        project.AddFile("Sample.cs", """
+            class Sample
+            {
+                [Meziantou.Analyzer.Annotations.ExcludeFromCancellationTokenAnalysis]
+                public static System.Threading.Tasks.Task FlushAsync() => System.Threading.Tasks.Task.CompletedTask;
+            }
+            """);
+        var data = await project.BuildAndGetOutput();
+        Assert.Equal(0, data.ExitCode);
+    }
+
+    [Fact]
     public async Task MTP_DotnetTestSkipAnalyzers()
     {
         await using var project = CreateProjectBuilder(SdkTestName);


### PR DESCRIPTION
## What

Adds an implicit `Meziantou.Analyzer.Annotations` package reference next to the existing `Meziantou.Analyzer` reference in `src/common/Common.props`.

## Why

`Meziantou.Analyzer.Annotations` is a separate package that ships the attributes used to configure several analyzer rules (`DoNotIgnore`, `ExcludeFromCancellationTokenAnalysis`, `RequireNamedArgument`, `CultureInsensitive`, ...). Since the SDK already brings in `Meziantou.Analyzer`, projects should be able to use those attributes without adding a package reference themselves.

## Notes for reviewers

Two deliberate differences from the `Meziantou.Analyzer` entry:

- **Condition** — excludes both `Meziantou.Analyzer` and `Meziantou.Analyzer.Annotations` as `PackageId`, since both packages come from the same repository and neither project should reference the annotations package.
- **Assets** — `compile` instead of `runtime`. The package ships a real `lib/netstandard2.0` assembly, so `compile` is required for the attributes to be usable. `runtime` is excluded on purpose: with it, `Meziantou.Analyzer.Annotations.dll` is copied into every project's output folder (this made `PdbShouldBeEmbedded_Dotnet_Build` fail, as it expects a single dll in the output). This is safe because the package removes attribute usages from the compiled assembly metadata by default. A project that opts into keeping them (`MEZIANTOU_ANALYZER_ANNOTATIONS` symbol) can add its own `PackageReference` to get the runtime asset.

## Tests

- `MeziantouAnalyzerAnnotationsCsproj` — mirrors the existing `MeziantouAnalyzerCsproj` test for the self-reference exclusion.
- `MeziantouAnalyzerAnnotationsAreReferenced` — builds a project using one of the attributes to verify the compile assets flow.

Full test suite passes locally: 356/356 (350 before the new tests).