### PR TITLE
Limit the assets imported from NuGet packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ Set these properties in your project file or a directory-level props file. Unles
 | `NuGetAuditLevel` | `low` | Minimum severity level to report. |
 | `WarningsAsErrors` | Adds `NU1900`–`NU1904` on CI, Release, or AI agent runtime | Promotes NuGet audit warnings to errors. |
 
+## NuGet package assets
+
+The SDK limits the assets imported from NuGet packages to the compile-time and runtime assemblies, so the analyzers, source generators, MSBuild props/targets, content files and native libraries shipped by a package are not imported:
+
+````xml
+<PackageReference Include="Some.Package" Version="1.2.3" IncludeAssets="runtime;compile" />
+````
+
+A reference is left untouched when it already sets `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, when the SDK adds it, or when its package id matches `DefaultPackageIncludeAssetsExcludedPackagePattern`. The default pattern covers `Meziantou.*` and `Microsoft.*` packages, as well as the test frameworks supported by the SDK (`xunit*`, `TUnit*`, `NUnit*`, `MSTest*`), as they rely on the source generators and the MSBuild props/targets they ship.
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `EnableDefaultPackageIncludeAssets` | `true` | Set to `false` to keep the default NuGet asset selection. |
+| `DefaultPackageIncludeAssets` | `runtime;compile` | Assets imported from the packages that are not excluded. |
+| `DefaultPackageIncludeAssetsExcludedPackagePattern` | ``^(?i:(Meziantou\|Microsoft)\.\|xunit\|TUnit\|NUnit\|MSTest)`` | .NET regular expression matched against the package id. A package whose id matches keeps the default NuGet asset selection. |
+
 ## Banned symbols and analyzers
 
 The SDK also blocks selected NuGet packages by default:

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -134,6 +134,56 @@
 		       Condition="'$(AllowPackage_Meziantou_Xunit_v3_ParallelTestFramework)' != 'true' AND (@(PackageReference->AnyHaveMetadataValue('Identity', 'Meziantou.Xunit.v3.ParallelTestFramework')) == 'true' OR @(ReferencePath->AnyHaveMetadataValue('NuGetPackageId', 'Meziantou.Xunit.v3.ParallelTestFramework')) == 'true')" />
 	</Target>
 
+  <!-- Limit the assets imported from NuGet packages to the compile-time and runtime assemblies -->
+  <!-- Packages can also ship analyzers, source generators, MSBuild props/targets, content files and native
+       libraries. Those assets are not imported by default, as they can slow down the build or change it in
+       unexpected ways.
+       A reference is left untouched when it already sets 'IncludeAssets', 'ExcludeAssets' or 'PrivateAssets',
+       when it is added by the SDK, or when its package id matches
+       'DefaultPackageIncludeAssetsExcludedPackagePattern'. The default pattern covers 'Meziantou.*' and
+       'Microsoft.*' packages, as well as the test frameworks supported by the SDK, as they rely on the
+       source generators and the MSBuild props/targets they ship.
+       Set 'EnableDefaultPackageIncludeAssets' to 'false' to opt out, or 'DefaultPackageIncludeAssets' to
+       change the imported assets. -->
+  <PropertyGroup>
+    <DefaultPackageIncludeAssets Condition="'$(DefaultPackageIncludeAssets)' == ''">runtime;compile</DefaultPackageIncludeAssets>
+    <DefaultPackageIncludeAssetsExcludedPackagePattern Condition="'$(DefaultPackageIncludeAssetsExcludedPackagePattern)' == ''">^(?i:(Meziantou|Microsoft)\.|xunit|TUnit|NUnit|MSTest)</DefaultPackageIncludeAssetsExcludedPackagePattern>
+    <_DefaultPackageIncludeAssetsIncludesAnalyzers Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefaultPackageIncludeAssets)', '(?i:(^|;)\s*(all|analyzers)\s*(;|$))'))">true</_DefaultPackageIncludeAssetsIncludesAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultPackageIncludeAssets)' != 'false'">
+    <PackageReference Update="@(PackageReference)">
+      <!-- The metadata is set first, so the other conditions can rely on it instead of being duplicated -->
+      <_UsesDefaultPackageIncludeAssets Condition="'%(IncludeAssets)' == '' AND
+                                                   '%(ExcludeAssets)' == '' AND
+                                                   '%(PrivateAssets)' == '' AND
+                                                   '%(IsImplicitlyDefined)' != 'true' AND
+                                                   !$([System.Text.RegularExpressions.Regex]::IsMatch('%(Identity)', '$(DefaultPackageIncludeAssetsExcludedPackagePattern)'))">true</_UsesDefaultPackageIncludeAssets>
+      <IncludeAssets Condition="'%(_UsesDefaultPackageIncludeAssets)' == 'true'">$(DefaultPackageIncludeAssets)</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- The .NET SDK resolves the analyzers of a direct package reference whatever its 'IncludeAssets' value is,
+       so the analyzers of the restricted packages are removed explicitly -->
+  <Target Name="RemoveAnalyzersFromRestrictedPackages"
+          BeforeTargets="CoreCompile"
+          Condition="'$(EnableDefaultPackageIncludeAssets)' != 'false' AND '$(_DefaultPackageIncludeAssetsIncludesAnalyzers)' != 'true'">
+    <ItemGroup>
+      <_RestrictedPackage Include="@(PackageReference)" Condition="'%(PackageReference._UsesDefaultPackageIncludeAssets)' == 'true'" />
+    </ItemGroup>
+
+    <!-- Item lists are not expanded in the arguments of a property function, so the value is lowercased in a second step -->
+    <PropertyGroup>
+      <_RestrictedPackageIds>;@(_RestrictedPackage);</_RestrictedPackageIds>
+      <_RestrictedPackageIds>$(_RestrictedPackageIds.ToLowerInvariant())</_RestrictedPackageIds>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.NuGetPackageId)' != '' AND $(_RestrictedPackageIds.Contains($([System.String]::Copy(';%(Analyzer.NuGetPackageId);').ToLowerInvariant())))" />
+    </ItemGroup>
+  </Target>
+
 	<!-- NuGet Package -->
 	<Choose>
 		<When Condition="'$(PackageIcon)' == '' AND '$(_IsMeziantouProject)' == 'true'">

--- a/tests/Meziantou.Sdk.Tests/Helpers/BuildResult.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/BuildResult.cs
@@ -36,6 +36,34 @@ internal sealed record BuildResult(int ExitCode, IReadOnlyList<string> OutputLin
         return result;
     }
 
+    public string GetMSBuildItemMetadata(string itemName, string itemSpec, string metadataName)
+    {
+        string result = null;
+        using var stream = new MemoryStream(BinaryLogContent);
+        var build = Serialization.ReadBinLog(stream);
+        build.VisitAllChildren<Item>(item =>
+        {
+            if (item.Parent is AddItem parent && parent.Name == itemName && string.Equals(item.Name, itemSpec, StringComparison.OrdinalIgnoreCase))
+            {
+                var metadata = item.Children.OfType<Metadata>().LastOrDefault(metadata => string.Equals(metadata.Name, metadataName, StringComparison.OrdinalIgnoreCase));
+                if (metadata is not null)
+                {
+                    result = metadata.Value;
+                }
+            }
+        });
+
+        return result;
+    }
+
+    public string GetCompilerCommandLineArguments()
+    {
+        using var stream = new MemoryStream(BinaryLogContent);
+        var build = Serialization.ReadBinLog(stream);
+        var task = build.FindLastDescendant<Microsoft.Build.Logging.StructuredLogger.Task>(task => task.Name is "Csc" or "Vbc" or "Fsc");
+        return task?.FindChild<Property>(property => property.Name is "CommandLineArguments")?.Value;
+    }
+
     public string GetMSBuildPropertyValue(string name)
     {
         using var stream = new MemoryStream(BinaryLogContent);

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -251,8 +251,11 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
             TestContext.Current.TestOutputHelper.WriteLine("Binlog file: " + file);
         }
 
+        // macos may prefix the path with /private
+        var localFileWithPrivatePrefix = FullPath.FromPath("/private" + localFile);
+
         Assert.Contains(files, f => f.EndsWith(".editorconfig", StringComparison.Ordinal));
-        Assert.Contains(files, f => f == localFile || f == "/private" + localFile); // macos may prefix it with /private
+        Assert.Contains(files, f => FullPathComparer.Default.Equals(FullPath.FromPath(f), localFile) || FullPathComparer.Default.Equals(FullPath.FromPath(f), localFileWithPrivatePrefix));
     }
 
     [Fact]
@@ -836,6 +839,105 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         project.AddFile("Program.cs", """System.Console.WriteLine();""");
         var data = await project.BuildAndGetOutput();
 
+        Assert.Equal(0, data.ExitCode);
+        Assert.Contains("Roslynator", data.GetCompilerCommandLineArguments(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_IsRestrictedWithCentralPackageManagement()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddFile("Directory.Packages.props", """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+              </ItemGroup>
+            </Project>
+            """);
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup", new XElement("PackageReference", new XAttribute("Include", "Newtonsoft.Json"))),
+        ]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Equal("runtime;compile", data.GetMSBuildItemMetadata("PackageReference", "Newtonsoft.Json", "IncludeAssets"));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_IsNotRestrictedForExcludedPackagesWithCentralPackageManagement()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddFile("Directory.Packages.props", """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup", new XElement("PackageReference", new XAttribute("Include", "Microsoft.Extensions.Logging"))),
+        ]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Null(data.GetMSBuildItemMetadata("PackageReference", "Microsoft.Extensions.Logging", "IncludeAssets"));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_AnalyzersFromPackagesAreNotImportedWithCentralPackageManagement()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddFile("Directory.Packages.props", """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1" />
+              </ItemGroup>
+            </Project>
+            """);
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup", new XElement("PackageReference", new XAttribute("Include", "Roslynator.Analyzers"))),
+        ]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("Roslynator", data.GetCompilerCommandLineArguments(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // 'GlobalPackageReference' is meant for the packages providing analyzers and MSBuild logic, so it must not be restricted
+    [Fact]
+    public async Task PackageIncludeAssets_GlobalPackageReferenceIsNotRestricted()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddFile("Directory.Packages.props", """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <GlobalPackageReference Include="Roslynator.Analyzers" Version="4.14.1" />
+              </ItemGroup>
+            </Project>
+            """);
+        project.AddCsprojFile();
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
         Assert.Contains("Roslynator", data.GetCompilerCommandLineArguments(), StringComparison.OrdinalIgnoreCase);
     }
 

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -54,6 +54,12 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
                 var nodes = doc.Descendants("PackageReference");
                 foreach (var node in nodes)
                 {
+                    // 'Update' items only change the metadata of an existing reference, so they don't need to be flagged as implicit
+                    if (node.Attribute("Include") is null)
+                    {
+                        continue;
+                    }
+
                     var attr = node.Attribute("IsImplicitlyDefined");
                     if (attr is null || attr.Value != "true")
                     {
@@ -723,6 +729,114 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         var data = await project.BuildAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_IsRestrictedByDefault()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(nuGetPackages: [new NuGetReference("Newtonsoft.Json", "13.0.4")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Equal("runtime;compile", data.GetMSBuildItemMetadata("PackageReference", "Newtonsoft.Json", "IncludeAssets"));
+    }
+
+    [Theory]
+    [InlineData("Microsoft.Extensions.Logging", "9.0.0")]
+    [InlineData("Meziantou.Framework", "6.0.2")]
+    [InlineData("xunit.v3", "4.0.0")]
+    [InlineData("TUnit", "1.22.19")]
+    public async Task PackageIncludeAssets_IsNotRestrictedForExcludedPackages(string packageName, string packageVersion)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(nuGetPackages: [new NuGetReference(packageName, packageVersion)]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Null(data.GetMSBuildItemMetadata("PackageReference", packageName, "IncludeAssets"));
+    }
+
+    [Theory]
+    [InlineData("IncludeAssets", "all")]
+    [InlineData("ExcludeAssets", "none")]
+    [InlineData("PrivateAssets", "all")]
+    public async Task PackageIncludeAssets_IsNotRestrictedWhenTheReferenceConfiguresItsAssets(string metadataName, string metadataValue)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup",
+                new XElement("PackageReference",
+                    new XAttribute("Include", "Newtonsoft.Json"),
+                    new XAttribute("Version", "13.0.4"),
+                    new XElement(metadataName, metadataValue))),
+        ]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Equal(metadataName is "IncludeAssets" ? metadataValue : null, data.GetMSBuildItemMetadata("PackageReference", "Newtonsoft.Json", "IncludeAssets"));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_CanBeDisabled()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("EnableDefaultPackageIncludeAssets", "false")], nuGetPackages: [new NuGetReference("Newtonsoft.Json", "13.0.4")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Null(data.GetMSBuildItemMetadata("PackageReference", "Newtonsoft.Json", "IncludeAssets"));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_CanBeConfigured()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("DefaultPackageIncludeAssets", "compile")], nuGetPackages: [new NuGetReference("Newtonsoft.Json", "13.0.4")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Equal("compile", data.GetMSBuildItemMetadata("PackageReference", "Newtonsoft.Json", "IncludeAssets"));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_ExcludedPackagePatternCanBeConfigured()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("DefaultPackageIncludeAssetsExcludedPackagePattern", "^Newtonsoft\\.")], nuGetPackages: [new NuGetReference("Newtonsoft.Json", "13.0.4")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Null(data.GetMSBuildItemMetadata("PackageReference", "Newtonsoft.Json", "IncludeAssets"));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_AnalyzersFromPackagesAreNotImported()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(nuGetPackages: [new NuGetReference("Roslynator.Analyzers", "4.14.1")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("Roslynator", data.GetCompilerCommandLineArguments(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_AnalyzersFromPackagesAreImportedWhenDisabled()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("EnableDefaultPackageIncludeAssets", "false")], nuGetPackages: [new NuGetReference("Roslynator.Analyzers", "4.14.1")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Contains("Roslynator", data.GetCompilerCommandLineArguments(), StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -918,6 +918,55 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.DoesNotContain("Roslynator", data.GetCompilerCommandLineArguments(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task PackageIncludeAssets_BuildAssetsFromPackagesAreNotImported()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(nuGetPackages: [new NuGetReference("coverlet.msbuild", "6.0.4")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain(data.GetBinLogFiles(), file => file.EndsWith("coverlet.msbuild.props", StringComparison.OrdinalIgnoreCase) || file.EndsWith("coverlet.msbuild.targets", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_BuildAssetsFromPackagesAreImportedWhenDisabled()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("EnableDefaultPackageIncludeAssets", "false")], nuGetPackages: [new NuGetReference("coverlet.msbuild", "6.0.4")]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Contains(data.GetBinLogFiles(), file => file.EndsWith("coverlet.msbuild.targets", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PackageIncludeAssets_BuildAssetsFromPackagesAreNotImportedWithCentralPackageManagement()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddFile("Directory.Packages.props", """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
+              </ItemGroup>
+            </Project>
+            """);
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup", new XElement("PackageReference", new XAttribute("Include", "coverlet.msbuild"))),
+        ]);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain(data.GetBinLogFiles(), file => file.EndsWith("coverlet.msbuild.props", StringComparison.OrdinalIgnoreCase) || file.EndsWith("coverlet.msbuild.targets", StringComparison.OrdinalIgnoreCase));
+    }
+
     // 'GlobalPackageReference' is meant for the packages providing analyzers and MSBuild logic, so it must not be restricted
     [Fact]
     public async Task PackageIncludeAssets_GlobalPackageReferenceIsNotRestricted()


### PR DESCRIPTION
## What

The SDK now restricts what a NuGet package contributes to a build to the compile-time and runtime assemblies:

```xml
<PackageReference Include="Some.Package" Version="1.2.3" IncludeAssets="runtime;compile" />
```

Analyzers, source generators, MSBuild props/targets, content files and native libraries shipped by a package are no longer imported.

| Property | Default | Description |
| --- | --- | --- |
| `EnableDefaultPackageIncludeAssets` | `true` | Set to `false` to keep the default NuGet asset selection. |
| `DefaultPackageIncludeAssets` | `runtime;compile` | Assets imported from the packages that are not excluded. |
| `DefaultPackageIncludeAssetsExcludedPackagePattern` | `^(?i:(Meziantou\|Microsoft)\.\|xunit\|TUnit\|NUnit\|MSTest)` | Regular expression matched against the package id. |

A reference is left untouched when it already sets `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, when the SDK adds it (`IsImplicitlyDefined`), or when its package id matches the exclusion pattern.

## Why

Those extra assets slow down the build and can change it in unexpected ways. Skipping references that already configure their assets keeps the usual `PrivateAssets="all"` analyzer references working.

## Notes for reviewers

- **The metadata is applied at evaluation time**, not from a target: with `RestoreUseStaticGraphEvaluation` enabled (the SDK sets it), restore reads `PackageReference` from the evaluation and never runs a target that could mutate it.

- **`IncludeAssets` alone does not disable source generators.** Measured on both .NET SDK 10 and 11: build props/targets, content files and native assets are filtered correctly, but `ResolvePackageAssets` passes a *direct* reference's analyzers to the compiler regardless of the asset flags — even with `ExcludeAssets="all"`. `RemoveAnalyzersFromRestrictedPackages` therefore drops the `@(Analyzer)` items of the restricted packages, following the existing `Disable_SponsorLink` pattern.

- **The test frameworks are excluded alongside `Meziantou.*` and `Microsoft.*`.** Restricting `xunit*`, `TUnit*`, `NUnit*` and `MSTest*` breaks `Meziantou.NET.Sdk.Test` projects that reference a framework explicitly, as those rely on the generators and targets the frameworks ship.

- **`System.*` is not excluded**, so `System.Text.Json`'s source generator is disabled for a project referencing that package explicitly. Adding `System` to `DefaultPackageIncludeAssetsExcludedPackagePattern` is a one-word change if that is not wanted.

- `PackageReferenceAreValid` now skips `Update` items, which only change the metadata of an existing reference and so don't need `IsImplicitlyDefined="true"`.

## Tests

13 new cases (26 across both SDK versions) covering the default value, the excluded packages, each of the three "already configured" metadata, both opt-outs, a custom exclusion pattern, and analyzers being dropped/kept. The analyzer assertions read the compiler command line from the binlog, since `@(Analyzer)` entries there record what was added, not what survived the removal.

`dotnet test`: 378 passed, 0 failed.