### PR TITLE
Remove the MSTest, TUnit and NUnit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ The SDK limits the assets imported from NuGet packages to the compile-time and r
 <PackageReference Include="Some.Package" Version="1.2.3" IncludeAssets="runtime;compile" />
 ````
 
-A reference is left untouched when it already sets `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, when the SDK adds it, or when its package id matches `DefaultPackageIncludeAssetsExcludedPackagePattern`. The default pattern covers `Meziantou.*` and `Microsoft.*` packages, as well as the test frameworks supported by the SDK (`xunit*`, `TUnit*`, `NUnit*`, `MSTest*`), as they rely on the source generators and the MSBuild props/targets they ship.
+A reference is left untouched when it already sets `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, when the SDK adds it, or when its package id matches `DefaultPackageIncludeAssetsExcludedPackagePattern`. The default pattern covers `Meziantou.*` and `Microsoft.*` packages, as well as the test framework supported by the SDK (`xunit*`), as they rely on the source generators and the MSBuild props/targets they ship.
 
 | Property | Default | Description |
 | --- | --- | --- |
 | `EnableDefaultPackageIncludeAssets` | `true` | Set to `false` to keep the default NuGet asset selection. |
 | `DefaultPackageIncludeAssets` | `runtime;compile` | Assets imported from the packages that are not excluded. |
-| `DefaultPackageIncludeAssetsExcludedPackagePattern` | ``^(?i:(Meziantou\|Microsoft)\.\|xunit\|TUnit\|NUnit\|MSTest)`` | .NET regular expression matched against the package id. A package whose id matches keeps the default NuGet asset selection. |
+| `DefaultPackageIncludeAssetsExcludedPackagePattern` | ``^(?i:(Meziantou\|Microsoft)\.\|xunit)`` | .NET regular expression matched against the package id. A package whose id matches keeps the default NuGet asset selection. |
 
 ## Banned symbols and analyzers
 
@@ -230,11 +230,10 @@ following to `global.json` so `dotnet test` runs in MTP mode:
 tests that passed — the option belongs to `dotnet test` itself, so it cannot be set from the project
 file.
 
-To use another test framework, reference it: the default framework is not added when the project
-already references `xunit`, `xunit.v3*`, `TUnit`, `MSTest`, or `NUnit`. Set
-`EnableDefaultTestFramework` to `false` for full control. Only Microsoft Testing Platform is
-supported, so the framework must run on it: the SDK never adds `Microsoft.NET.Test.Sdk` and
-configures no VSTest setting.
+To use another xUnit.net package, reference it: the default framework is not added when the project
+already references `xunit` or `xunit.v3*`. Set `EnableDefaultTestFramework` to `false` for full
+control. Only Microsoft Testing Platform is supported, so the test framework must run on it: the SDK
+never adds `Microsoft.NET.Test.Sdk` and configures no VSTest setting.
 
 The assertions come from
 [`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions)

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -141,13 +141,13 @@
        A reference is left untouched when it already sets 'IncludeAssets', 'ExcludeAssets' or 'PrivateAssets',
        when it is added by the SDK, or when its package id matches
        'DefaultPackageIncludeAssetsExcludedPackagePattern'. The default pattern covers 'Meziantou.*' and
-       'Microsoft.*' packages, as well as the test frameworks supported by the SDK, as they rely on the
+       'Microsoft.*' packages, as well as the test framework supported by the SDK, as they rely on the
        source generators and the MSBuild props/targets they ship.
        Set 'EnableDefaultPackageIncludeAssets' to 'false' to opt out, or 'DefaultPackageIncludeAssets' to
        change the imported assets. -->
   <PropertyGroup>
     <DefaultPackageIncludeAssets Condition="'$(DefaultPackageIncludeAssets)' == ''">runtime;compile</DefaultPackageIncludeAssets>
-    <DefaultPackageIncludeAssetsExcludedPackagePattern Condition="'$(DefaultPackageIncludeAssetsExcludedPackagePattern)' == ''">^(?i:(Meziantou|Microsoft)\.|xunit|TUnit|NUnit|MSTest)</DefaultPackageIncludeAssetsExcludedPackagePattern>
+    <DefaultPackageIncludeAssetsExcludedPackagePattern Condition="'$(DefaultPackageIncludeAssetsExcludedPackagePattern)' == ''">^(?i:(Meziantou|Microsoft)\.|xunit)</DefaultPackageIncludeAssetsExcludedPackagePattern>
     <_DefaultPackageIncludeAssetsIncludesAnalyzers Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefaultPackageIncludeAssets)', '(?i:(^|;)\s*(all|analyzers)\s*(;|$))'))">true</_DefaultPackageIncludeAssetsIncludesAnalyzers>
   </PropertyGroup>
 

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -33,12 +33,7 @@
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.mtp-off')) != 'true' AND
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core')) != 'true' AND
                         @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-v2')) != 'true' AND
-                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-off')) != 'true' AND
-                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'TUnit')) != 'true' AND
-                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'TUnit.Core')) != 'true' AND
-                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'MSTest')) != 'true' AND
-                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'MSTest.TestFramework')) != 'true' AND
-                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'NUnit')) != 'true'">
+                        @(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'xunit.v3.core.mtp-off')) != 'true'">
     <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0" IsImplicitlyDefined="true" />
 
     <!-- An item is used instead of a property as item lists cannot be referenced in a property condition outside of a target (MSB4099) -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -29,10 +29,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         new NuGetReference("xunit.v3.mtp-v2", "4.0.0"),
         new NuGetReference("xunit.runner.visualstudio", "4.0.0"),
     ];
-    private static readonly NuGetReference[] TUnitReferences =
-    [
-        new NuGetReference("TUnit", "1.22.19"),
-    ];
 
     private ProjectBuilder CreateProjectBuilder(string defaultSdkName = SdkName)
     {
@@ -750,7 +746,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     [InlineData("Microsoft.Extensions.Logging", "9.0.0")]
     [InlineData("Meziantou.Framework", "6.0.2")]
     [InlineData("xunit.v3", "4.0.0")]
-    [InlineData("TUnit", "1.22.19")]
     public async Task PackageIncludeAssets_IsNotRestrictedForExcludedPackages(string packageName, string packageVersion)
     {
         await using var project = CreateProjectBuilder();
@@ -1431,43 +1426,6 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
     }
 
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task MTP_SuccessTests_TUnit(bool addUseMicrosoftTestingPlatformProperty)
-    {
-        await using var project = CreateProjectBuilder(SdkTestName);
-        project.AddCsprojFile(
-            filename: "Sample.Tests.csproj",
-            properties: addUseMicrosoftTestingPlatformProperty ? [("UseMicrosoftTestingPlatform", "true")] : [],
-            nuGetPackages: [.. TUnitReferences]
-            );
-
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Test]
-                public void Test1()
-                {
-                }
-            }
-            """);
-
-        project.AddFile("global.json", """
-            {
-                "test": {
-                    "runner": "Microsoft.Testing.Platform"
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput();
-
-        Assert.Equal(0, data.ExitCode);
-        Assert.NotEmpty(Directory.GetFiles(project.RootFolder, "*.trx", SearchOption.AllDirectories));
-        Assert.True(data.IsMSBuildTargetExecuted("_MTPBuild"));
-    }
-
     [Fact]
     public async Task MTP_NoTest()
     {
@@ -1533,18 +1491,18 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task MTP_DefaultTestFramework_NotAddedWhenAnotherFrameworkIsReferenced()
+    public async Task MTP_DefaultTestFramework_NotAddedWhenATestFrameworkIsReferenced()
     {
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. TUnitReferences]
+            nuGetPackages: [.. XUnit3References]
             );
 
         project.AddFile("Program.cs", """
             public class Tests
             {
-                [Test]
+                [Fact]
                 public void Test1()
                 {
                 }
@@ -1695,21 +1653,20 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
 
     // The package must not replace the assertions of a test framework referenced by the project itself
     [Fact]
-    public async Task MTP_MeziantouAssertions_NotAddedForAnotherTestFramework()
+    public async Task MTP_MeziantouAssertions_NotAddedWhenATestFrameworkIsReferenced()
     {
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. TUnitReferences]
+            nuGetPackages: [.. XUnit3References]
             );
 
+        // 'Assert' must still be resolved to the xUnit.net type
         project.AddFile("Program.cs", """
             public class Tests
             {
-                [Test]
-                public void Test1()
-                {
-                }
+                [Fact]
+                public void Test1() => Assert.Equal(typeof(Xunit.Assert), typeof(Assert));
             }
             """);
 
@@ -1901,35 +1858,19 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.True(data.OutputContains("'XunitParallelizationMode' has an invalid value: 'Collection'.", StringComparison.Ordinal));
     }
 
-    // 'Xunit.v3.ParallelizationAttribute' doesn't exist in another test framework, so the file must not be generated
+    // 'Xunit.v3.ParallelizationAttribute' is only available when xUnit.net v3 is referenced, so the file must not be generated
     [Fact]
-    public async Task MTP_XunitFullParallelization_NotGeneratedForAnotherTestFramework()
+    public async Task MTP_XunitFullParallelization_NotGeneratedWhenXunitIsNotReferenced()
     {
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. TUnitReferences]
+            properties: [("EnableDefaultTestFramework", "false")]
             );
 
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Test]
-                public void Test1()
-                {
-                }
-            }
-            """);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
 
-        project.AddFile("global.json", """
-            {
-                "test": {
-                    "runner": "Microsoft.Testing.Platform"
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput();
+        var data = await project.BuildAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
         Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitParallelization", StringComparison.Ordinal));
@@ -2030,37 +1971,22 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitStaticHelpers", StringComparison.Ordinal));
     }
 
-    // 'Xunit.TestContext' doesn't exist in another test framework, so the file must not be generated
+    // 'Xunit.TestContext' is only available when xUnit.net v3 is referenced, so the file must not be generated
     [Fact]
-    public async Task MTP_XunitStaticHelpers_NotGeneratedForAnotherTestFramework()
+    public async Task MTP_XunitStaticHelpers_NotGeneratedWhenXunitIsNotReferenced()
     {
         await using var project = CreateProjectBuilder(SdkTestName);
         project.AddCsprojFile(
             filename: "Sample.Tests.csproj",
-            nuGetPackages: [.. TUnitReferences]
+            properties: [("EnableDefaultTestFramework", "false")]
             );
 
-        project.AddFile("Program.cs", """
-            public class Tests
-            {
-                [Test]
-                public void Test1()
-                {
-                }
-            }
-            """);
+        project.AddFile("Program.cs", """System.Console.WriteLine();""");
 
-        project.AddFile("global.json", """
-            {
-                "test": {
-                    "runner": "Microsoft.Testing.Platform"
-                }
-            }
-            """);
-
-        var data = await project.TestAndGetOutput();
+        var data = await project.BuildAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
+        Assert.False(data.IsMSBuildTargetExecuted("GenerateXunitStaticHelpersSourceFile"));
         Assert.DoesNotContain(data.GetMSBuildItems("Compile"), item => item.Contains("XunitStaticHelpers", StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
xUnit.net is the only test framework the SDK supports, so this removes the logic, tests and documentation dealing with MSTest, TUnit and NUnit.

## What changed

**SDK logic**

- `src/common/Tests.targets`: the condition guarding the default test framework no longer checks for `TUnit`, `TUnit.Core`, `MSTest`, `MSTest.TestFramework` and `NUnit`. Only the xUnit.net package ids remain, so referencing one of the removed frameworks no longer prevents the SDK from adding `xunit.v3.mtp-v2`.
- `src/common/Common.targets`: `DefaultPackageIncludeAssetsExcludedPackagePattern` is now `^(?i:(Meziantou|Microsoft)\.|xunit)` instead of `^(?i:(Meziantou|Microsoft)\.|xunit|TUnit|NUnit|MSTest)`, so those packages get the default `runtime;compile` asset selection like any other package.

**Documentation**

- `README.md`: removed the three frameworks from the NuGet asset paragraph, from the `DefaultPackageIncludeAssetsExcludedPackagePattern` default in the property table, and from the "use another test framework" paragraph.

**Tests**

- Removed the `TUnitReferences` field, the `[InlineData("TUnit", …)]` case of `PackageIncludeAssets_IsNotRestrictedForExcludedPackages`, and `MTP_SuccessTests_TUnit`.
- Four other tests used TUnit only as a stand-in for "some other test framework" while actually covering xUnit.net specific logic that still exists. The coverage is kept and re-expressed without TUnit:
  - `MTP_DefaultTestFramework_NotAddedWhenATestFrameworkIsReferenced` and `MTP_MeziantouAssertions_NotAddedWhenATestFrameworkIsReferenced` now reference `xunit.v3` directly. The assertions one also asserts that `Assert` still resolves to `Xunit.Assert`.
  - `MTP_XunitFullParallelization_NotGeneratedWhenXunitIsNotReferenced` and `MTP_XunitStaticHelpers_NotGeneratedWhenXunitIsNotReferenced` now build a project with `EnableDefaultTestFramework=false` and no test framework at all, which exercises the same auto-detection guard without needing a second framework. The static helpers one also asserts the generating target does not run.

## Notes for reviewers

- This is a behavior change for projects referencing MSTest, TUnit or NUnit: the SDK now also adds `xunit.v3.mtp-v2` to them, and restricts their assets to `runtime;compile`. Such projects have to set `EnableDefaultTestFramework=false` and, if needed, `DefaultPackageIncludeAssetsExcludedPackagePattern`.
- `.gitignore` still mentions MSTest and NUnit, but only in the boilerplate comments naming test-result folders, so it was left untouched.

## Testing

Full suite run locally: 386 tests, 0 failed, 0 skipped.