### PR TITLE
Enable the strict System.Text.Json serialization defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ Set these properties in your project file or a directory-level props file. Unles
 | `EnforceCodeStyleInBuild` | `true` on CI or Release | Enforces analyzer code style during builds. |
 | `AccelerateBuildsInVisualStudio` | `true` | Enables faster builds in Visual Studio. |
 
+## JSON serialization
+
+The SDK enables the `System.Text.Json` behaviors that honor the nullable reference type annotations and the `required` constructor parameters, so the deserialization is consistent with what the type declares:
+
+````xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault" Value="true" />
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault" Value="true" />
+</ItemGroup>
+````
+
+A switch explicitly set by the project is left untouched.
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `EnableDefaultJsonSerializationOptions` | `true` | Set to `false` to keep the default `System.Text.Json` behaviors. |
+
 ## Package validation and auditing
 
 | Property | Default | Description |

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -57,6 +57,20 @@
 		<PackAsTool Condition="'$(PackAsTool)' == '' AND '$(OutputType)' == 'Exe' AND '$(IsTestProject)' != 'true'">true</PackAsTool>
 	</PropertyGroup>
 
+  <!-- Opt in to the 'System.Text.Json' behaviors that honor the nullable reference type annotations and the
+       'required' constructor parameters. Both are opt-in in the runtime for backward compatibility, but they
+       make the deserialization consistent with what the type declares.
+       A switch explicitly set by the project is left untouched.
+       Set 'EnableDefaultJsonSerializationOptions' to 'false' to opt out. -->
+  <ItemGroup Condition="'$(EnableDefaultJsonSerializationOptions)' != 'false'">
+    <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault"
+                                    Value="true"
+                                    Condition="@(RuntimeHostConfigurationOption->AnyHaveMetadataValue('Identity', 'System.Text.Json.Serialization.RespectNullableAnnotationsDefault')) != 'true'" />
+    <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault"
+                                    Value="true"
+                                    Condition="@(RuntimeHostConfigurationOption->AnyHaveMetadataValue('Identity', 'System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault')) != 'true'" />
+  </ItemGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>Meziantou.Sdk.Name</_Parameter1>

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1,5 +1,6 @@
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Reflection.PortableExecutable;
+using System.Text.Json;
 using System.Xml.Linq;
 using NuGet.Packaging;
 using Task = System.Threading.Tasks.Task;
@@ -119,6 +120,65 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         project.AddCsprojFile(properties: [("OutputType", "Library")]);
         var data = await project.BuildAndGetOutput();
         data.AssertMSBuildPropertyValue("RollForward", "LatestMajor");
+    }
+
+    [Fact]
+    public async Task JsonSerializationOptions_AreEnabledByDefault()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Program.cs", "System.Console.WriteLine();");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Equal("true", GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectNullableAnnotationsDefault"));
+        Assert.Equal("true", GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault"));
+    }
+
+    [Fact]
+    public async Task JsonSerializationOptions_CanBeDisabled()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("EnableDefaultJsonSerializationOptions", "false")]);
+        project.AddFile("Program.cs", "System.Console.WriteLine();");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Null(GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectNullableAnnotationsDefault"));
+        Assert.Null(GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault"));
+    }
+
+    [Theory]
+    [InlineData("System.Text.Json.Serialization.RespectNullableAnnotationsDefault")]
+    [InlineData("System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault")]
+    public async Task JsonSerializationOptions_CanBeOverriddenByTheProject(string switchName)
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(additionalProjectElements:
+        [
+            new XElement("ItemGroup",
+                new XElement("RuntimeHostConfigurationOption",
+                    new XAttribute("Include", switchName),
+                    new XAttribute("Value", "false"))),
+        ]);
+        project.AddFile("Program.cs", "System.Console.WriteLine();");
+        var data = await project.BuildAndGetOutput();
+
+        Assert.Equal(0, data.ExitCode);
+        Assert.Equal("false", GetRuntimeConfigProperty(project, switchName));
+    }
+
+    private static string GetRuntimeConfigProperty(ProjectBuilder project, string name)
+    {
+        var path = Directory.GetFiles(project.RootFolder / "bin", "*.runtimeconfig.json", SearchOption.AllDirectories).Single();
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        if (document.RootElement.GetProperty("runtimeOptions").TryGetProperty("configProperties", out var configProperties) &&
+            configProperties.TryGetProperty(name, out var value))
+        {
+            return value.GetRawText();
+        }
+
+        return null;
     }
 
     [Fact]

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO.Compression;
 using System.Reflection.PortableExecutable;
-using System.Text.Json;
 using System.Xml.Linq;
 using NuGet.Packaging;
 using Task = System.Threading.Tasks.Task;
@@ -127,12 +126,12 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     {
         await using var project = CreateProjectBuilder();
         project.AddCsprojFile();
-        project.AddFile("Program.cs", "System.Console.WriteLine();");
-        var data = await project.BuildAndGetOutput();
+        AddJsonSerializationSampleFiles(project);
+        var data = await project.RunAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
-        Assert.Equal("true", GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectNullableAnnotationsDefault"));
-        Assert.Equal("true", GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault"));
+        Assert.True(data.OutputContains("RespectNullableAnnotations=enabled", StringComparison.Ordinal));
+        Assert.True(data.OutputContains("RespectRequiredConstructorParameters=enabled", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -140,18 +139,18 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     {
         await using var project = CreateProjectBuilder();
         project.AddCsprojFile(properties: [("EnableDefaultJsonSerializationOptions", "false")]);
-        project.AddFile("Program.cs", "System.Console.WriteLine();");
-        var data = await project.BuildAndGetOutput();
+        AddJsonSerializationSampleFiles(project);
+        var data = await project.RunAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
-        Assert.Null(GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectNullableAnnotationsDefault"));
-        Assert.Null(GetRuntimeConfigProperty(project, "System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault"));
+        Assert.True(data.OutputContains("RespectNullableAnnotations=disabled", StringComparison.Ordinal));
+        Assert.True(data.OutputContains("RespectRequiredConstructorParameters=disabled", StringComparison.Ordinal));
     }
 
     [Theory]
-    [InlineData("System.Text.Json.Serialization.RespectNullableAnnotationsDefault")]
-    [InlineData("System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault")]
-    public async Task JsonSerializationOptions_CanBeOverriddenByTheProject(string switchName)
+    [InlineData("System.Text.Json.Serialization.RespectNullableAnnotationsDefault", "RespectNullableAnnotations")]
+    [InlineData("System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault", "RespectRequiredConstructorParameters")]
+    public async Task JsonSerializationOptions_CanBeOverriddenByTheProject(string switchName, string disabledBehavior)
     {
         await using var project = CreateProjectBuilder();
         project.AddCsprojFile(additionalProjectElements:
@@ -161,24 +160,42 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
                     new XAttribute("Include", switchName),
                     new XAttribute("Value", "false"))),
         ]);
-        project.AddFile("Program.cs", "System.Console.WriteLine();");
-        var data = await project.BuildAndGetOutput();
+        AddJsonSerializationSampleFiles(project);
+        var data = await project.RunAndGetOutput();
 
         Assert.Equal(0, data.ExitCode);
-        Assert.Equal("false", GetRuntimeConfigProperty(project, switchName));
+        Assert.True(data.OutputContains(disabledBehavior + "=disabled", StringComparison.Ordinal));
+
+        // The switch that is not set by the project keeps the value set by the SDK
+        var otherBehavior = disabledBehavior is "RespectNullableAnnotations" ? "RespectRequiredConstructorParameters" : "RespectNullableAnnotations";
+        Assert.True(data.OutputContains(otherBehavior + "=enabled", StringComparison.Ordinal));
     }
 
-    private static string GetRuntimeConfigProperty(ProjectBuilder project, string name)
+    private static void AddJsonSerializationSampleFiles(ProjectBuilder project)
     {
-        var path = Directory.GetFiles(project.RootFolder / "bin", "*.runtimeconfig.json", SearchOption.AllDirectories).Single();
-        using var document = JsonDocument.Parse(File.ReadAllText(path));
-        if (document.RootElement.GetProperty("runtimeOptions").TryGetProperty("configProperties", out var configProperties) &&
-            configProperties.TryGetProperty(name, out var value))
-        {
-            return value.GetRawText();
-        }
+        project.AddFile("Sample.cs", "internal sealed record Sample(string Name, int Value);");
+        project.AddFile("Program.cs", """"
+            using System.Text.Json;
 
-        return null;
+            // 'Name' is not nullable, so the payload is rejected when the nullable annotations are respected
+            Console.WriteLine("RespectNullableAnnotations=" + (IsRejected("""{"Name":null,"Value":1}""") ? "enabled" : "disabled"));
+
+            // 'Value' has no default value, so the payload is rejected when the required constructor parameters are respected
+            Console.WriteLine("RespectRequiredConstructorParameters=" + (IsRejected("""{"Name":"dummy"}""") ? "enabled" : "disabled"));
+
+            static bool IsRejected(string json)
+            {
+                try
+                {
+                    _ = JsonSerializer.Deserialize<Sample>(json);
+                    return false;
+                }
+                catch (JsonException)
+                {
+                    return true;
+                }
+            }
+            """");
     }
 
     [Fact]


### PR DESCRIPTION
## What

The SDK now sets two `System.Text.Json` feature switches for every project:

```xml
<RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault" Value="true" />
<RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault" Value="true" />
```

## Why

Both behaviors are opt-in in the runtime for backward compatibility. Without them, `System.Text.Json` happily deserializes `null` into a non-nullable property and skips a `required` constructor parameter, which contradicts what the type already declares — exactly the kind of mismatch the SDK's `Nullable=enable` default is meant to prevent.

## Notes for reviewers

- The items live in `Common.targets`, not `Common.props`. `Common.targets` is imported through `BeforeMicrosoftNETSdkTargets`, so the project's own items are already evaluated when the conditions run.
- Two guards, following the conventions already used in this file (`EnableDefaultPackageIncludeAssets`, `FailOnBannedPackageReferences`):
  - `EnableDefaultJsonSerializationOptions=false` opts out of both switches.
  - A per-switch `AnyHaveMetadataValue('Identity', …)` condition skips a switch the project already declares, so a project setting `Value="false"` keeps its value instead of getting a duplicate entry in `runtimeconfig.json`.
- The .NET SDK exposes no MSBuild property for these two switches (checked against the installed 11.0.100 targets — only `JsonSerializerIsReflectionEnabledByDefault` and friends are mapped), so the raw items are the only way to set them.
- The switches are honored by `System.Text.Json` 9.0+. On older targets the `runtimeconfig.json` entry is simply ignored, and for libraries it is not emitted at all.

## Tests

Four tests in `SdkTests.cs` assert on the generated `runtimeconfig.json` rather than on the MSBuild items: enabled by default, disabled through the property, and overridable per switch by the project. They run against both the .NET 10 and .NET 11 SDK fixtures.

Full suite: 398/398 passing locally.