### PR TITLE
Update Meziantou.Analyzer to 3.0.224 and enable MA0221, MA0222, MA0223

### DIFF
--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -88,7 +88,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.206" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.224" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
@@ -929,11 +929,6 @@ dotnet_diagnostic.MA0185.severity = suggestion
 # Enabled: False, Severity: suggestion
 dotnet_diagnostic.MA0186.severity = suggestion
 
-# MA0186: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
-# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0186.md
-# Enabled: False, Severity: suggestion
-dotnet_diagnostic.MA0186.severity = suggestion
-
 # MA0187: Use constructor injection instead of [Inject] attribute
 # Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0187.md
 # Enabled: False, Severity: suggestion
@@ -1103,4 +1098,19 @@ dotnet_diagnostic.MA0219.severity = silent
 # Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md
 # Enabled: True, Severity: warning
 dotnet_diagnostic.MA0220.severity = warning
+
+# MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md
+# Enabled: False, Severity: suggestion
+dotnet_diagnostic.MA0221.severity = warning
+
+# MA0222: JsonSourceGenerationOptions should set RespectNullableAnnotations
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0222.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0222.severity = warning
+
+# MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0223.severity = warning
 

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -730,6 +730,30 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task DefaultEditorConfig_MA0222_MA0223_AreReportedAsWarnings()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Sample.cs", """
+            using System.Text.Json.Serialization;
+
+            class Sample
+            {
+                public string? Name { get; set; }
+            }
+
+            [JsonSerializable(typeof(Sample))]
+            partial class SampleJsonSerializerContext : JsonSerializerContext
+            {
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput(["--configuration", "Debug"]);
+        Assert.True(data.HasWarning("MA0222"));
+        Assert.True(data.HasWarning("MA0223"));
+    }
+
+    [Fact]
     public async Task NuGetAuditIsReportedAsErrorOnGitHubActions()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
## What changed

- Bumped `Meziantou.Analyzer` from **3.0.206** to **3.0.224** in `src/common/Common.props`.
- Regenerated `src/configuration/Analyzer.Meziantou.Analyzer.editorconfig` with `tools/ConfigFilesGenerator`.
- Enabled the three new rules as **warnings**:
  - `MA0221` — TryGetValue method should use `[MaybeNullWhen(false)]` on the value parameter
  - `MA0222` — JsonSourceGenerationOptions should set `RespectNullableAnnotations`
  - `MA0223` — JsonSourceGenerationOptions should set `RespectRequiredConstructorParameters`
- Added `DefaultEditorConfig_MA0222_MA0223_AreReportedAsWarnings` to `tests/Meziantou.Sdk.Tests/SdkTests.cs`, which builds a project containing a `JsonSerializerContext` without those options and asserts both warnings are reported.

## Why

`MA0222` and `MA0223` complement the strict `System.Text.Json` serialization defaults enabled in #221. Those defaults are applied through runtime host configuration switches, so they only affect the reflection-based serializer — a source-generated `JsonSerializerContext` has to opt in explicitly via `[JsonSourceGenerationOptions]`. These rules catch the contexts that silently miss out.

## Notes for reviewers

- The regeneration removes a **duplicate `MA0186` entry**. Upstream moved that diagnostic's TryGetValue variant to its own `MA0221` id, so the generated file no longer emits the same id twice. `MA0186` keeps its `suggestion` severity, so this is not a behavior change for it.
- `MA0221` is off by default upstream (the generator wrote `none`); it is explicitly set to `warning` here.
- No test asserts `MA0221`'s severity — only `MA0222`/`MA0223` are covered by the new test.

## Verification

- `dotnet run --project tools/ConfigFilesGenerator` reports `0 configuration files written` on a re-run, so the `lint_config` CI job stays clean and the severities survive regeneration.
- `dotnet build Meziantou.NET.Sdk.slnx` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/Meziantou.Sdk.Tests` — **400/400 passing** (398 before, +2 for the new test across the net10 and net11 SDK roots).