### PR TITLE
Fix flaky MSBuild property assertions by serializing binary log reads

### DIFF
--- a/tests/Meziantou.Sdk.Tests/Helpers/BuildResult.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/BuildResult.cs
@@ -4,6 +4,13 @@ namespace Meziantou.Sdk.Tests.Helpers;
 
 internal sealed record BuildResult(int ExitCode, IReadOnlyList<string> OutputLines, SarifFile SarifFile, byte[] BinaryLogContent)
 {
+    // MSBuild.StructuredLogger uses mutable static state, so reading several binary logs concurrently can produce an
+    // incomplete tree, such as a project evaluation with no property. Tests run in parallel, so the reads must be
+    // serialized. The result is cached because a single test reads the same binary log multiple times.
+    private static readonly Lock BinaryLogLock = new();
+
+    private Build _build;
+
     public bool OutputContains(string value, StringComparison stringComparison = StringComparison.Ordinal) => OutputLines.Any(line => line.Contains(value, stringComparison));
     public bool OutputDoesNotContain(string value, StringComparison stringComparison = StringComparison.Ordinal) => !OutputLines.Any(line => line.Contains(value, stringComparison));
 
@@ -13,18 +20,30 @@ internal sealed record BuildResult(int ExitCode, IReadOnlyList<string> OutputLin
     public bool HasWarning(string ruleId) => SarifFile.AllResults().Any(r => r.Level == "warning" && r.RuleId == ruleId);
     public bool HasNote(string ruleId) => SarifFile.AllResults().Any(r => r.Level == "note" && r.RuleId == ruleId);
 
+    private Build GetBuild()
+    {
+        lock (BinaryLogLock)
+        {
+            if (_build is null)
+            {
+                using var stream = new MemoryStream(BinaryLogContent);
+                _build = Serialization.ReadBinLog(stream);
+            }
+
+            return _build;
+        }
+    }
+
     public IReadOnlyCollection<string> GetBinLogFiles()
     {
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
+        var build = GetBuild();
         return [.. build.SourceFiles.Select(file => file.FullPath)];
     }
 
     public List<string> GetMSBuildItems(string name)
     {
         var result = new List<string>();
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
+        var build = GetBuild();
         build.VisitAllChildren<Item>(item =>
         {
             if (item.Parent is AddItem parent && parent.Name == name)
@@ -39,8 +58,7 @@ internal sealed record BuildResult(int ExitCode, IReadOnlyList<string> OutputLin
     public string GetMSBuildItemMetadata(string itemName, string itemSpec, string metadataName)
     {
         string result = null;
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
+        var build = GetBuild();
         build.VisitAllChildren<Item>(item =>
         {
             if (item.Parent is AddItem parent && parent.Name == itemName && string.Equals(item.Name, itemSpec, StringComparison.OrdinalIgnoreCase))
@@ -58,32 +76,27 @@ internal sealed record BuildResult(int ExitCode, IReadOnlyList<string> OutputLin
 
     public string GetCompilerCommandLineArguments()
     {
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
+        var build = GetBuild();
         var task = build.FindLastDescendant<Microsoft.Build.Logging.StructuredLogger.Task>(task => task.Name is "Csc" or "Vbc" or "Fsc");
         return task?.FindChild<Property>(property => property.Name is "CommandLineArguments")?.Value;
     }
 
     public string GetMSBuildPropertyValue(string name)
     {
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
+        var build = GetBuild();
         return build.FindLastDescendant<Property>(e => e.Name == name)?.Value;
     }
 
     public void AssertMSBuildPropertyValue(string name, string expectedValue, bool ignoreCase = true)
     {
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
-        var actual = build.FindLastDescendant<Property>(e => e.Name == name)?.Value;
+        var actual = GetMSBuildPropertyValue(name);
 
         Assert.Equal(expectedValue, actual, ignoreCase: ignoreCase);
     }
 
     public bool IsMSBuildTargetExecuted(string name)
     {
-        using var stream = new MemoryStream(BinaryLogContent);
-        var build = Serialization.ReadBinLog(stream);
+        var build = GetBuild();
         var target = build.FindLastDescendant<Target>(e => e.Name == name);
         if (target is null)
             return false;


### PR DESCRIPTION
## Problem

`LLMContextEnvironmentVariables_EnableWarningsAsErrors(ZED_ENVIRONMENT, "1")` failed in [this run](https://github.com/meziantou/Meziantou.NET.Sdk/actions/runs/34134657628/job/101783205373):

```
Assert.Equal() Failure: Strings differ
Expected: "true"
Actual:   null
   at BuildResult.AssertMSBuildPropertyValue(...)
   at SdkTests.LLMContextEnvironmentVariables_EnableWarningsAsErrors(...) SdkTests.cs:491
```

The assertion that failed is `MSBuildTreatWarningsAsErrors`, yet the two properties checked immediately before it — `IsLLMContext` and `_EnableWarningsAsErrors` — read fine, even though all three are set in the same `PropertyGroup` in `src/common/Common.props`.

## Root cause

I downloaded the binary log that the failing test itself attached to the run artifacts and parsed it: it **does** contain `MSBuildTreatWarningsAsErrors = true`. The build was correct; the *reading* of the binary log was wrong.

`MSBuild.StructuredLogger` relies on mutable static state, so `Serialization.ReadBinLog` is not thread-safe. `BuildResult` re-parsed the whole binary log on **every** accessor call, so one test could issue up to six parses racing against the parses of the other tests running in parallel. When two parses overlap, one can come back with a project evaluation that has no property at all.

Reproduced standalone against the binary logs from the failed run:

| Parsing mode | Result over ~1560 parses |
| --- | --- |
| Parallel (`MaxDegreeOfParallelism = ProcessorCount`) | 1–6 spurious `null` results |
| Sequential (`MaxDegreeOfParallelism = 1`) | 0 failures |
| Parallel, lock around `ReadBinLog` only | 0 failures |

## Fix

All seven accessors now go through a single `GetBuild()` helper that reads the binary log under a static `Lock` and caches the parsed `Build` on the `BuildResult`. Traversals still run outside the lock, so there is no contention on the actual queries — and each test now parses its ~1 MB binary log once instead of up to six times.

## Note for reviewers

The file had inconsistent line endings (mixed CRLF/LF). Since `.editorconfig` specifies `end_of_line = lf` for `*`, the file is normalized to LF, which is why the raw diff looks larger than the change. `git diff --ignore-cr-at-eol` shows the real change is just the `GetBuild()` extraction.

## Verification

- `dotnet build tests/Meziantou.Sdk.Tests` — succeeded, 0 warnings, 0 errors.
- `dotnet test tests/Meziantou.Sdk.Tests` — **400/400 passed**, 0 failed, 0 skipped (includes all 52 `LLMContextEnvironmentVariables_EnableWarningsAsErrors` cases).