### PR TITLE
Rename the xUnit disable-warnings constant to XUNIT_GENERATED_DISABLE_WARNINGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,10 @@ the missing `partial` modifier:
 </PropertyGroup>
 ````
 
-The SDK also defines the `XUNIT_ENTRYPOINT_DISABLE_WARNINGS` compilation constant in every test project:
+The SDK also defines the `XUNIT_GENERATED_DISABLE_WARNINGS` compilation constant in every test project:
 
 ````csharp
-#if XUNIT_ENTRYPOINT_DISABLE_WARNINGS
+#if XUNIT_GENERATED_DISABLE_WARNINGS
 // ...
 #endif
 ````
@@ -353,7 +353,7 @@ Set `EnableXunitEntryPointDisableWarnings` to `false` to not define it:
 | `EnableXunitFullParallelization` | Auto | Generates a source file with `[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.All)]` so every test runs in parallel, not just test collections. Generated when xUnit.net v3 4.0 or later is resolved, when set to `true` whatever the resolved references are, and never when set to `false`. |
 | `XunitParallelizationMode` | `All` | Sets the `Xunit.Sdk.ParallelMode` value used by the generated attribute: `None`, `Collections` or `All`. Setting it also generates the source file whatever the resolved references are. The file is not generated when `EnableXunitFullParallelization` is `false`. |
 | `EnableXunitStaticHelpers` | Auto | Generates the `Meziantou.NET.Sdk.Test.XUnitStaticHelpers` static class exposing `XunitCancellationToken` (`TestContext.Current.CancellationToken`). Generated when an xUnit.net v3 package is referenced, when set to `true` whatever the referenced packages are, and never when set to `false`. The global `using static` directive requires `ImplicitUsings`. |
-| `EnableXunitEntryPointDisableWarnings` | `true` | Defines the `XUNIT_ENTRYPOINT_DISABLE_WARNINGS` compilation constant. Set it to `false` to not define the constant. |
+| `EnableXunitEntryPointDisableWarnings` | `true` | Defines the `XUNIT_GENERATED_DISABLE_WARNINGS` compilation constant. Set it to `false` to not define the constant. |
 | `EnableGitHubActionsReport` | `true` | Adds `Microsoft.Testing.Extensions.GitHubActionsReport` and `--report-gh --report-gh-slow-test-notices off --report-gh-step-summary $(GitHubActionsStepSummary)`. The extension is inert unless the build runs on GitHub Actions. Slow-test notices are disabled as they are mostly noise on CI machines with varying performance. |
 | `GitHubActionsStepSummary` | `on-failure` | Sets `--report-gh-step-summary`, which controls when the markdown job summary is written to `GITHUB_STEP_SUMMARY`: `on`, `off` or `on-failure`. The summary is written only for failing runs as it brings little value when everything succeeds. |
 | `EnableCodeCoverage` | `true` on CI | Enables code coverage collection on CI. |

--- a/src/common/Tests.targets
+++ b/src/common/Tests.targets
@@ -189,11 +189,12 @@
     </ItemGroup>
   </Target>
 
-  <!-- Define the 'XUNIT_ENTRYPOINT_DISABLE_WARNINGS' compilation constant. Set 'EnableXunitEntryPointDisableWarnings' to 'false' to opt out. -->
+  <!-- Define the 'XUNIT_GENERATED_DISABLE_WARNINGS' compilation constant. Set 'EnableXunitEntryPointDisableWarnings' to 'false' to opt out. -->
+  <!-- https://github.com/xunit/xunit/issues/3606#issuecomment-5590029144 -->
   <!-- Visual Basic separates the constants with ',' and requires a value for each of them, otherwise the compiler reports BC31030 -->
   <PropertyGroup Condition="'$(EnableXunitEntryPointDisableWarnings)' != 'false'">
-    <DefineConstants Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(DefineConstants),XUNIT_ENTRYPOINT_DISABLE_WARNINGS=-1</DefineConstants>
-    <DefineConstants Condition="'$(MSBuildProjectExtension)' != '.vbproj'">$(DefineConstants);XUNIT_ENTRYPOINT_DISABLE_WARNINGS</DefineConstants>
+    <DefineConstants Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(DefineConstants),XUNIT_GENERATED_DISABLE_WARNINGS=-1</DefineConstants>
+    <DefineConstants Condition="'$(MSBuildProjectExtension)' != '.vbproj'">$(DefineConstants);XUNIT_GENERATED_DISABLE_WARNINGS</DefineConstants>
   </PropertyGroup>
 
   <!-- Add implicit using for xunit -->

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -2112,8 +2112,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
         project.AddCsprojFile(filename: "Sample.Tests.csproj");
 
         project.AddFile("Program.cs", """
-            #if !XUNIT_ENTRYPOINT_DISABLE_WARNINGS
-            #error XUNIT_ENTRYPOINT_DISABLE_WARNINGS is not defined
+            #if !XUNIT_GENERATED_DISABLE_WARNINGS
+            #error XUNIT_GENERATED_DISABLE_WARNINGS is not defined
             #endif
 
             public class Tests
@@ -2140,8 +2140,8 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
             );
 
         project.AddFile("Program.cs", """
-            #if XUNIT_ENTRYPOINT_DISABLE_WARNINGS
-            #error XUNIT_ENTRYPOINT_DISABLE_WARNINGS is defined
+            #if XUNIT_GENERATED_DISABLE_WARNINGS
+            #error XUNIT_GENERATED_DISABLE_WARNINGS is defined
             #endif
 
             public class Tests


### PR DESCRIPTION
## What

Renames the compilation constant defined by the SDK in test projects from `XUNIT_ENTRYPOINT_DISABLE_WARNINGS` to `XUNIT_GENERATED_DISABLE_WARNINGS`.

## Why

xUnit.net is renaming the symbol because it now covers all the source generation done for Native AOT, not just the generated entry point: https://github.com/xunit/xunit/issues/3606#issuecomment-5590029144

## Changes

- `src/common/Tests.targets`: defines `XUNIT_GENERATED_DISABLE_WARNINGS` (both the C#/F# `;` form and the VB `,` + `=-1` form), with a link to the upstream comment.
- `README.md`: documentation and property table updated to the new name.
- `tests/Meziantou.Sdk.Tests/SdkTests.cs`: `MTP_XunitEntryPointDisableWarningsConstantIsDefined` and `MTP_XunitEntryPointDisableWarningsConstant_OptOut` now assert on the new name.

## Notes for reviewers

- Only the new name is defined; the old one is gone. This is a breaking change for any project with `#if XUNIT_ENTRYPOINT_DISABLE_WARNINGS`.
- The opt-out property is still named `EnableXunitEntryPointDisableWarnings`, so it no longer matches the constant name. Left as-is to avoid breaking projects that already set it — happy to rename it in a follow-up if preferred.

## Validation

`dotnet build` of the test project succeeds with 0 warnings, and the filtered test run passes 4/4 (the two tests x the SDK 10.0 and 11.0 variants).