### PR TITLE
Opt in to the updated memory safety rules and update .NET 11 to RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Set these properties in your project file or a directory-level props file. Unles
 | `AnalysisLevel` | `latest-all` | Uses the latest analyzer rules. |
 | `AllowUnsafeBlocks` | `true` | Allows `unsafe` code blocks. |
 | `LangVersion` | `latest` | Uses the latest C# language version. |
+| `MeziantouUpdatedMemorySafetyRules` | `true` when `LangVersion` is `preview` | Adds the `updated-memory-safety-rules` compiler feature, so `unsafe` members propagate the audit obligation to their callers. |
 | `MSBuildTreatWarningsAsErrors` | `true` on CI, Release, or AI agent runtime | Treats MSBuild warnings as errors. |
 | `TreatWarningsAsErrors` | `true` on CI, Release, or AI agent runtime | Treats compiler warnings as errors. |
 | `EnforceCodeStyleInBuild` | `true` on CI or Release | Enforces analyzer code style during builds. |

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -13,6 +13,21 @@
 		<NoWarn Condition="'$(DisableDocumentationWarnings)' != 'false'">$(NoWarn);CS1573;CS1591</NoWarn>
 	</PropertyGroup>
 
+  <!-- Opt in to the updated memory safety rules (https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/unsafe-evolution).
+       Under those rules 'unsafe' on a member makes it caller-unsafe: the obligation to audit the memory safety
+       propagates to the callers, which must invoke the member from an 'unsafe' context.
+
+       The rules are evaluated here rather than in 'Common.props' because 'Common.props' is imported before the
+       project file, so the language version chosen by the project is not known yet.
+
+       The compiler reports CS8652 when the feature is enabled under a language version older than 'preview', so
+       the rules are only enabled when the project opted into 'preview'. Older compilers ignore the unknown feature.
+       Set 'MeziantouUpdatedMemorySafetyRules' to 'false' to opt out, or to 'true' to opt in explicitly. -->
+  <PropertyGroup>
+    <MeziantouUpdatedMemorySafetyRules Condition="'$(MeziantouUpdatedMemorySafetyRules)' == '' AND '$(LangVersion)' == 'preview'">true</MeziantouUpdatedMemorySafetyRules>
+    <Features Condition="'$(MeziantouUpdatedMemorySafetyRules)' == 'true'">$(Features);updated-memory-safety-rules</Features>
+  </PropertyGroup>
+
 	<PropertyGroup Condition="'$(_IsGitHubActions)' == 'true' AND '$(UsingMicrosoftNETSdkWeb)' == 'true'">
 		<EnableSdkContainerSupport Condition="'$(EnableSdkContainerSupport)' == ''">true</EnableSdkContainerSupport>
 		<ContainerRegistry Condition="'$(ContainerRegistry)' == ''">ghcr.io</ContainerRegistry>

--- a/tests/Meziantou.Sdk.Tests/Helpers/DotNetSdkHelpers.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/DotNetSdkHelpers.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Sdk.Tests.Helpers;
 public static class DotNetSdkHelpers
 {
     private const string Net10SdkVersion = "10.0.400";
-    private const string Net11SdkVersion = "11.0.100-preview.7.26381.103";
+    private const string Net11SdkVersion = "11.0.100-rc.1.26425.128";
 
     private static readonly ConcurrentDictionary<NetSdkVersion, FullPath> Values = new();
     private static readonly KeyedAsyncLock<NetSdkVersion> KeyedAsyncLock = new();

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -259,6 +259,67 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task UpdatedMemorySafetyRules_DisabledByDefault()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("sample.cs", """
+            unsafe
+            {
+                int* p = null;
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("updated-memory-safety-rules", data.GetCompilerCommandLineArguments(), StringComparison.Ordinal);
+    }
+
+    // The compiler reports CS8652 when the feature is enabled under a language version older than 'preview',
+    // so an 'unsafe' member must keep compiling with the default language version
+    [Fact]
+    public async Task UpdatedMemorySafetyRules_UnsafeMemberCompilesWithDefaultLangVersion()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("OutputType", "Library")]);
+        project.AddFile("sample.cs", """
+            public static class Sample
+            {
+                public static unsafe int Read(int* value) => *value;
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput();
+        Assert.Equal(0, data.ExitCode);
+        Assert.False(data.HasError("CS8652"));
+    }
+
+    [Fact]
+    public async Task UpdatedMemorySafetyRules_EnabledWhenLangVersionIsPreview()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("LangVersion", "preview")]);
+        project.AddFile("sample.cs", "Console.WriteLine();");
+
+        var data = await project.BuildAndGetOutput();
+        Assert.Equal(0, data.ExitCode);
+        data.AssertMSBuildPropertyValue("MeziantouUpdatedMemorySafetyRules", "true");
+        Assert.Contains("updated-memory-safety-rules", data.GetCompilerCommandLineArguments(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UpdatedMemorySafetyRules_CanOptOut()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile(properties: [("LangVersion", "preview"), ("MeziantouUpdatedMemorySafetyRules", "false")]);
+        project.AddFile("sample.cs", "Console.WriteLine();");
+
+        var data = await project.BuildAndGetOutput();
+        Assert.Equal(0, data.ExitCode);
+        Assert.DoesNotContain("updated-memory-safety-rules", data.GetCompilerCommandLineArguments(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task StrictModeEnabled()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
## What changed

Two related changes for .NET 11:

**1. Opt in to the C# 15 updated memory safety rules** ([`src/common/Common.targets`](https://github.com/meziantou/meziantou.net.sdk/blob/feature/memory-safety-dotnet-11-24da28/src/common/Common.targets))

```xml
<MeziantouUpdatedMemorySafetyRules Condition="'$(MeziantouUpdatedMemorySafetyRules)' == '' AND '$(LangVersion)' == 'preview'">true</MeziantouUpdatedMemorySafetyRules>
<Features Condition="'$(MeziantouUpdatedMemorySafetyRules)' == 'true'">$(Features);updated-memory-safety-rules</Features>
```

Under the [unsafe evolution](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/unsafe-evolution) rules, `unsafe` on a member makes it *caller-unsafe*: the obligation to audit memory safety propagates to callers, which must invoke it from an `unsafe` context.

**2. Update the .NET 11 SDK used by the tests** from `11.0.100-preview.7.26381.103` to `11.0.100-rc.1.26425.128` (released 2026-09-08). `global.json` is untouched — the test helper was the only other .NET 11 pin in the repo.

## Why it is gated on `LangVersion`

`updated-memory-safety-rules` is a real Roslyn feature flag ([`Feature.cs`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/CommandLine/Feature.cs)) driving `MemorySafetyRulesVersion.Version2`, but [`CSharpCompilation.cs:3102`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs) rejects it unless the language version enables `IDS_FeatureUnsafeEvolution`, i.e. `preview`.

Verified against real compilers rather than the docs:

| Configuration | Result |
| --- | --- |
| .NET 11 SDK, `LangVersion=latest` + flag | `error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*` |
| .NET 11 SDK, `LangVersion=preview` + flag | Builds; a safe caller of an `unsafe` member correctly fails with `CS9362` |
| .NET 10 SDK + flag | Silently ignored, no error |

The SDK sets `LangVersion` to `latest` and ships to every consumer, so enabling the flag unconditionally would hard-break any consumer project with an `unsafe` member on the .NET 11 SDK — including this repo's own build.

## Notes for the reviewer

- **Why `Common.targets` and not `Common.props`:** `Common.props` arrives via `CustomBeforeDirectoryBuildProps`, so it is evaluated *before* the project file. `$(LangVersion)` there is always the SDK's own `latest`, never what the project chose. The gate only works at targets-evaluation time.
- **Judgment call worth a look:** this defaults **on** when `LangVersion=preview`, matching the SDK's opinionated style. It is a semantic change — a project that set `preview` for unrelated reasons will now get `CS9362` at call sites of its own `unsafe` members. To make it strictly opt-in instead, change the condition to require `MeziantouUpdatedMemorySafetyRules=true` explicitly.
- Documented in the properties table in `README.md`.

## Tests

4 new tests in `SdkTests.cs`, next to `AllowUnsafeBlock`, all running against both the .NET 10 and .NET 11 SDKs:

- `UpdatedMemorySafetyRules_DisabledByDefault`
- `UpdatedMemorySafetyRules_UnsafeMemberCompilesWithDefaultLangVersion` — regression guard for the CS8652 break
- `UpdatedMemorySafetyRules_EnabledWhenLangVersionIsPreview`
- `UpdatedMemorySafetyRules_CanOptOut`

Full suite: **408/408 passed**, including all 204 .NET 11 tests re-run against the freshly downloaded RC1 SDK.