### PR TITLE
Exclude System.* packages from the default IncludeAssets restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ The SDK limits the assets imported from NuGet packages to the compile-time and r
 <PackageReference Include="Some.Package" Version="1.2.3" IncludeAssets="runtime;compile" />
 ````
 
-A reference is left untouched when it already sets `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, when the SDK adds it, or when its package id matches `DefaultPackageIncludeAssetsExcludedPackagePattern`. The default pattern covers `Meziantou.*` and `Microsoft.*` packages, as well as the test framework supported by the SDK (`xunit*`), as they rely on the source generators and the MSBuild props/targets they ship.
+A reference is left untouched when it already sets `IncludeAssets`, `ExcludeAssets` or `PrivateAssets`, when the SDK adds it, or when its package id matches `DefaultPackageIncludeAssetsExcludedPackagePattern`. The default pattern covers `Meziantou.*`, `Microsoft.*` and `System.*` packages, as well as the test framework supported by the SDK (`xunit*`), as they rely on the source generators and the MSBuild props/targets they ship.
 
 | Property | Default | Description |
 | --- | --- | --- |
 | `EnableDefaultPackageIncludeAssets` | `true` | Set to `false` to keep the default NuGet asset selection. |
 | `DefaultPackageIncludeAssets` | `runtime;compile` | Assets imported from the packages that are not excluded. |
-| `DefaultPackageIncludeAssetsExcludedPackagePattern` | ``^(?i:(Meziantou\|Microsoft)\.\|xunit)`` | .NET regular expression matched against the package id. A package whose id matches keeps the default NuGet asset selection. |
+| `DefaultPackageIncludeAssetsExcludedPackagePattern` | ``^(?i:(Meziantou\|Microsoft\|System)\.\|xunit)`` | .NET regular expression matched against the package id. A package whose id matches keeps the default NuGet asset selection. |
 
 ## Banned symbols and analyzers
 

--- a/src/common/Common.targets
+++ b/src/common/Common.targets
@@ -169,14 +169,14 @@
        unexpected ways.
        A reference is left untouched when it already sets 'IncludeAssets', 'ExcludeAssets' or 'PrivateAssets',
        when it is added by the SDK, or when its package id matches
-       'DefaultPackageIncludeAssetsExcludedPackagePattern'. The default pattern covers 'Meziantou.*' and
-       'Microsoft.*' packages, as well as the test framework supported by the SDK, as they rely on the
-       source generators and the MSBuild props/targets they ship.
+       'DefaultPackageIncludeAssetsExcludedPackagePattern'. The default pattern covers 'Meziantou.*',
+       'Microsoft.*' and 'System.*' packages, as well as the test framework supported by the SDK, as they
+       rely on the source generators and the MSBuild props/targets they ship.
        Set 'EnableDefaultPackageIncludeAssets' to 'false' to opt out, or 'DefaultPackageIncludeAssets' to
        change the imported assets. -->
   <PropertyGroup>
     <DefaultPackageIncludeAssets Condition="'$(DefaultPackageIncludeAssets)' == ''">runtime;compile</DefaultPackageIncludeAssets>
-    <DefaultPackageIncludeAssetsExcludedPackagePattern Condition="'$(DefaultPackageIncludeAssetsExcludedPackagePattern)' == ''">^(?i:(Meziantou|Microsoft)\.|xunit)</DefaultPackageIncludeAssetsExcludedPackagePattern>
+    <DefaultPackageIncludeAssetsExcludedPackagePattern Condition="'$(DefaultPackageIncludeAssetsExcludedPackagePattern)' == ''">^(?i:(Meziantou|Microsoft|System)\.|xunit)</DefaultPackageIncludeAssetsExcludedPackagePattern>
     <_DefaultPackageIncludeAssetsIncludesAnalyzers Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefaultPackageIncludeAssets)', '(?i:(^|;)\s*(all|analyzers)\s*(;|$))'))">true</_DefaultPackageIncludeAssetsIncludesAnalyzers>
   </PropertyGroup>
 

--- a/tests/Meziantou.Sdk.Tests/Helpers/TestPackages.cs
+++ b/tests/Meziantou.Sdk.Tests/Helpers/TestPackages.cs
@@ -29,6 +29,7 @@ internal static class TestPackages
     // Library packages whose names are excluded from the default 'IncludeAssets' restriction
     public const string MicrosoftLibrary = "Microsoft.TestPackage";
     public const string MeziantouLibrary = "Meziantou.TestPackage";
+    public const string SystemLibrary = "System.TestPackage";
     public const string XunitLibrary = "xunit.TestPackage";
 
     /// <summary>Package providing a Roslyn analyzer.</summary>
@@ -46,7 +47,7 @@ internal static class TestPackages
 
     private static string[] BannedPackages => [YamlDotNet, CliWrap, Testcontainers, MeziantouXunitParallelTestFramework, MeziantouXunitV3ParallelTestFramework];
 
-    private static string[] LibraryPackages => [Library, MicrosoftLibrary, MeziantouLibrary, XunitLibrary, .. BannedPackages];
+    private static string[] LibraryPackages => [Library, MicrosoftLibrary, MeziantouLibrary, SystemLibrary, XunitLibrary, .. BannedPackages];
 
     public static IEnumerable<string> PackageIds => [.. LibraryPackages, Analyzer, BuildAssets];
 

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -920,6 +920,7 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     [Theory]
     [InlineData(TestPackages.MicrosoftLibrary)]
     [InlineData(TestPackages.MeziantouLibrary)]
+    [InlineData(TestPackages.SystemLibrary)]
     [InlineData(TestPackages.XunitLibrary)]
     public async Task PackageIncludeAssets_IsNotRestrictedForExcludedPackages(string packageName)
     {


### PR DESCRIPTION
## What changed

`System.*` packages are now excluded from the default `IncludeAssets` restriction applied by the SDK.

- `src/common/Common.targets`: the default `DefaultPackageIncludeAssetsExcludedPackagePattern` goes from ``^(?i:(Meziantou|Microsoft)\.|xunit)`` to ``^(?i:(Meziantou|Microsoft|System)\.|xunit)``, and the surrounding comment is updated.
- `README.md`: documents `System.*` in the prose and in the properties table.
- `tests/.../Helpers/TestPackages.cs`: adds a `System.TestPackage` library package to the generated test packages.
- `tests/.../SdkTests.cs`: `PackageIncludeAssets_IsNotRestrictedForExcludedPackages` now covers `System.TestPackage`.

## Why

The SDK restricts package assets to `runtime;compile` by default, which drops the analyzers, source generators, MSBuild props/targets, content files and native libraries a package ships. `System.*` packages are published by the .NET team alongside the `Microsoft.*` ones and rely on those assets, so they belong in the same exclusion list as the other first-party packages.

## Notes for reviewers

Only the default value changes; projects that set `DefaultPackageIncludeAssetsExcludedPackagePattern` explicitly are unaffected, and `EnableDefaultPackageIncludeAssets` / `DefaultPackageIncludeAssets` behave as before.

Verified: the test project builds with 0 warnings, and the filtered run `--filter-query "/*/*/*/PackageIncludeAssets*"` passed 40/40, including the new `packageName: "System.TestPackage"` case.