### PR TITLE
Update Meziantou.Analyzer to 3.0.234 and enable the new rules

### DIFF
--- a/src/common/Common.props
+++ b/src/common/Common.props
@@ -88,7 +88,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.224" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.234" Condition="$(PackageId) != 'Meziantou.Analyzer'" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
+++ b/src/configuration/Analyzer.Meziantou.Analyzer.editorconfig
@@ -1114,3 +1114,78 @@ dotnet_diagnostic.MA0222.severity = warning
 # Enabled: False, Severity: warning
 dotnet_diagnostic.MA0223.severity = warning
 
+# MA0224: JsonSerializerOptions should set RespectNullableAnnotations
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0224.severity = warning
+
+# MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0225.severity = warning
+
+# MA0226: EventSource class should be sealed
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0226.severity = warning
+
+# MA0227: Avoid using 'Enumerable.Contains' on a set
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0227.severity = warning
+
+# MA0228: The event id of an EventSource must be greater than zero
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0228.severity = warning
+
+# MA0229: The event id of an EventSource is already used by another event
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0229.severity = warning
+
+# MA0230: The event name of an EventSource is already used by another event
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0230.severity = warning
+
+# MA0231: An EventSource event method must not be static
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0231.severity = warning
+
+# MA0232: An EventSource event method must not be an explicit interface implementation
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0232.severity = warning
+
+# MA0233: An abstract EventSource must not declare event methods
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0233.severity = warning
+
+# MA0234: The event id written by an EventSource event method must match its [Event] attribute
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0234.severity = warning
+
+# MA0235: The payload written by an EventSource event method must match its parameters
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0235.severity = warning
+
+# MA0236: The payload written by an EventSource event method must use the order of its parameters
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0236.severity = warning
+
+# MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0237.severity = warning
+
+# MA0238: The parameter type of an EventSource event method is not supported
+# Help link: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md
+# Enabled: False, Severity: warning
+dotnet_diagnostic.MA0238.severity = warning
+

--- a/tests/Meziantou.Sdk.Tests/SdkTests.cs
+++ b/tests/Meziantou.Sdk.Tests/SdkTests.cs
@@ -815,6 +815,66 @@ public abstract class SdkTests(PackageFixture fixture, ITestOutputHelper testOut
     }
 
     [Fact]
+    public async Task DefaultEditorConfig_MA0224_MA0225_AreReportedAsWarnings()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Sample.cs", """
+            using System.Text.Json;
+
+            class Sample
+            {
+                public JsonSerializerOptions Test() => new JsonSerializerOptions();
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput(["--configuration", "Debug"]);
+        Assert.True(data.HasWarning("MA0224"));
+        Assert.True(data.HasWarning("MA0225"));
+    }
+
+    [Fact]
+    public async Task DefaultEditorConfig_MA0226_IsReportedAsWarning()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Sample.cs", """
+            using System.Diagnostics.Tracing;
+
+            class SampleEventSource : EventSource
+            {
+                public static SampleEventSource Log { get; } = new SampleEventSource();
+
+                [Event(1)]
+                public void Start() => WriteEvent(1);
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput(["--configuration", "Debug"]);
+        Assert.True(data.HasWarning("MA0226"));
+    }
+
+    [Fact]
+    public async Task DefaultEditorConfig_MA0227_IsReportedAsWarning()
+    {
+        await using var project = CreateProjectBuilder();
+        project.AddCsprojFile();
+        project.AddFile("Sample.cs", """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class Sample
+            {
+                public bool Test(HashSet<string> set, string value) => set.Contains(value, StringComparer.Ordinal);
+            }
+            """);
+
+        var data = await project.BuildAndGetOutput(["--configuration", "Debug"]);
+        Assert.True(data.HasWarning("MA0227"));
+    }
+
+    [Fact]
     public async Task NuGetAuditIsReportedAsErrorOnGitHubActions()
     {
         await using var project = CreateProjectBuilder();


### PR DESCRIPTION
Bump `Meziantou.Analyzer` from 3.0.224 to 3.0.234 and regenerate the analyzer configuration file with `tools/ConfigFilesGenerator`.

## New rules

The upgrade brings 15 new rules. All of them are **disabled by default** upstream, and all of them declare a **default severity of `warning`**, so the generated configuration is edited to enable them at that severity.

| Rule | Title |
| --- | --- |
| MA0224 / MA0225 | `JsonSerializerOptions` should set `RespectNullableAnnotations` / `RespectRequiredConstructorParameters` |
| MA0227 | Avoid using `Enumerable.Contains` on a set |
| MA0226, MA0228–MA0238 | `EventSource` correctness: sealed class, event id/name validity and uniqueness, non-static and non-explicit-interface event methods, no events on abstract sources, `WriteEvent` id/payload/order matching, activity-id parameter position, supported parameter types |

MA0224/MA0225 are the `JsonSerializerOptions` counterparts of MA0222/MA0223, which the SDK already reports as warnings, and they complement the strict `System.Text.Json` defaults enabled by #221.

Most of the `EventSource` rules report code that silently produces no event at runtime, which makes them a good fit for the default configuration.

## Notes for the reviewer

The generator writes `none` for the rules that are disabled by default, so the 15 severities in the configuration file were changed to `warning` by hand. The generator preserves the severities already present in the file, so running it again after this change is a no-op — verified by re-running it (`0 configuration files written`).

Three tests are added next to the existing MA0222/MA0223 one to check that the newly enabled rules are actually reported, since a rule that is disabled by default only fires because of the severity set in the configuration file.

## Validation

- `./build.ps1` packs the six SDK packages without warnings.
- `dotnet test tests/Meziantou.Sdk.Tests` passes 416/416 (408 before, plus the 3 new tests run against the two SDK variants).